### PR TITLE
fixed typo in readme, make slack -> make stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ by the runtime module.
 
 ### Step 3. Install Troupe top-level scripts
 
-Type `make slack` to compile Troupe's bin scripts
+Type `make stack` to compile Troupe's bin scripts
 
 ### Step 4. Install Troupe standard library
 


### PR DESCRIPTION
the "make slack" in the readme appears to be a typo, as there is no slack target in the makefile, while there is a "stack" target.