### PR TITLE
Fix generated argument names

### DIFF
--- a/compiler/src/CaseElimination.hs
+++ b/compiler/src/CaseElimination.hs
@@ -31,7 +31,7 @@ transLit (S.LAtom a)   = T.LAtom a
 
 
 transLambda_aux (S.Lambda pats t) =
-  let args = map (("arg" ++) . show) [1..(length pats)]
+  let args = map (("$arg" ++) . show) [1..(length pats)]
       argPat = zip (map Var args) pats
       t' = foldM compilePattern (transTerm t) (reverse argPat)
   in Lambda args <$> t'


### PR DESCRIPTION
Currently names "arg1", "arg2", ... were generated, which would lead to conflicts when the program uses these argument names and result in runtime errors