### PR TITLE
Sparsebit improvements

### DIFF
--- a/rt/src/Thread.mts
+++ b/rt/src/Thread.mts
@@ -212,9 +212,7 @@ export class Thread {
     next :  () => any;
     callStack : any []
     _sp : number;
-    boundSlot : number;
-    
-    _isDataBoundByPC: boolean = false;
+    sparseSlot : number; // slot on the stack holding the sparse bit (whether data is bounded by PC)
     
     processDebuggingName: string;
 
@@ -250,7 +248,7 @@ export class Thread {
         ---> stack growth direction --->
 
         |---------+-------------------+--------------+-----------------------------+---------------+-------------------------+--------------------|
-        | sp_prev | pc at return site | ret callback | mclear at the time of entry | branching bit | [escaping locals]       | bound_slot         |
+        | sp_prev | pc at return site | ret callback | mclear at the time of entry | branching bit | [escaping locals]       | sparse slot        |
         |---------+-------------------+--------------+-----------------------------+---------------+-------------------------+--------------------|
         | sp - 5  | sp - 4            | sp - 3       | sp - 2                      | sp - 1        | sp ... (sp + framesize) | sp + framesize + 1 |
 
@@ -329,7 +327,7 @@ export class Thread {
 
     showStack ()  {
         console.log ("======== SHOW STACK ========= ")
-        console.log (`sp = ${this._sp} boundslot = ${this.boundSlot}`)
+        console.log (`sp = ${this._sp} sparseSlot = ${this.sparseSlot}`)
         let j = this._sp - 1 
         let stack = this.callStack
         while ( j > 0) {
@@ -365,46 +363,51 @@ export class Thread {
         return f;
     }
 
-
-    invalidateSparseBit () {
-        this.callStack[this.boundSlot] = false;
+    getSparseBit() {
+        return this.callStack[this.sparseSlot]
     }
 
-    // Check whether the label of R0 (argument), the data level of R0 and the given one are bound by PC.
-    checkDataBoundsEntry (x: Level) {
-        const _pc = this.pc 
-        let y = 
-             flowsTo(this.r0_lev, _pc) 
-              && 
-                flowsTo (x, _pc)
-                    && (this.r0_val._troupeType == undefined 
-                                ? true
-                                : flowsTo (this.r0_val.dataLevel, _pc)
-                        )
-             
-                                    
-        // this._isDataBoundByPC = y;    
-        return y;
+    invalidateSparseBit() {
+        this.callStack[this.sparseSlot] = false;
     }
 
-    // Check whether the label of R0 (return value) and the data level of R0 are bound by PC.
-    // Return false if x is false.
-    // TODO Better check x directly and do not call this function if false (now that _isDataBoundByPC is not updated).
-    checkDataBounds (x: boolean) {
-        const _pc = this.pc 
-        let y = 
-             x? flowsTo(this.r0_lev, _pc) 
-                    && (this.r0_val._troupeType == undefined 
-                                ? true
-                                : flowsTo (this.r0_val.dataLevel, _pc)
-                        )
-             : false 
-                                    
-        // this._isDataBoundByPC = y;    
-        return y;
+    private setSparseBit(b: boolean) {
+        this.callStack[this.sparseSlot] = b;
     }
 
-    
+    /**
+     * Check whether the label of R0 (argument), the data level of R0 and the given label are bound by PC
+     * and update sparse bit accordingly.
+     */
+    updateSparseBitOnEntry(x: Level) {
+        const _pc = this.pc
+        // Only non-basic types (_troupeType is defined) have a data level. For those, it
+        // is sufficient to check r0_val.dataLevel ⊑ _pc, as r0_lev ⊑ r0_val.dataLev. For
+        // base types, we instead have to check r0_lev ⊑ _pc.
+        if (this.r0_val._troupeType != undefined) {
+            this.setSparseBit(flowsTo(x, _pc) && flowsTo(this.r0_val.dataLevel, _pc))
+        } else {
+            this.setSparseBit(flowsTo(x, _pc) && flowsTo(this.r0_lev, _pc))
+        }
+    }
+
+    /**
+     * If the sparse bit is set, check whether it is still valid for the returned value (and reset it if not):
+     * Check whether the label of R0 (return value) and the data level of R0 are bound by PC.
+     */
+    updateSparseBitOnReturn() {
+        const _pc = this.pc
+        if (this.getSparseBit()) {
+            // Only non-basic types (_troupeType is defined) have a data level. For those, it
+            // is sufficient to check r0_val.dataLevel ⊑ _pc, as r0_lev ⊑ r0_val.dataLev. For
+            // base types, we instead have to check r0_lev ⊑ _pc.
+            if (this.r0_val._troupeType != undefined) {
+                this.setSparseBit(flowsTo(this.r0_val.dataLevel, _pc))
+            } else {
+                this.setSparseBit(flowsTo(this.r0_lev, _pc))
+            }
+        }
+    }
 
 
     runNext (theFun, args, nm)  {
@@ -619,8 +622,7 @@ export class Thread {
 
 
     blockdeclto (auth, bl_to = this.pc) {        
-        let is_bounded_by_pc = flowsTo (this.pc, bl_to);
-        if (!is_bounded_by_pc) {
+        if (! flowsTo (this.pc, bl_to)) {
             this.threadError ("The provided target blocking level is lower than the current pc\n" + 
                               ` | the current pc: ${this.pc.stringRep()}\n` +
                               ` | target blocking level: ${bl_to.stringRep()}`)

--- a/rt/src/builtins/UserRuntimeZero.mts
+++ b/rt/src/builtins/UserRuntimeZero.mts
@@ -92,20 +92,9 @@ export class UserRuntimeZero {
         this.runtime.ret (x)
     }
 
-    join (...xs) {
-        if (this.runtime.$t._isDataBoundByPC) {
-            return this.runtime.$t.pc 
-        } 
+    // SimpleRT
+    raw_join(...xs) : Level {
         return lub.apply (null, xs)
-    }
-
-    wrap_block_rhs (x) {
-        if (this.runtime.$t._isDataBoundByPC) {
-            return this.runtime.$t.bl 
-        } else {
-            return x;
-        }
-        
     }
 
     // SpecialRT


### PR DESCRIPTION
- Remove remainders from an earlier refactoring (the local variable `_isDataBoundByPC` is not used)
  - The check for this variable in UserRuntimeZero was thus always false
  - The variable was used in the runtime operation `join`, to only apply joins if data is not
    bounded by PC. However, the branching to avoid such joins is already inserted by Stack2JS,
    thus it is redundant here and probably a remainder from earlier refactoring.
  - The runtime function `wrap_block_rhs` is redundant. It was used in the context of updating
    the blocking label through code generated in Stack2JS. It just returned the label to set
    the blocking label to, if the sparse bit is not set, and the current blocking label otherwise.
    Again this optimization is unnecessary here, as Stack2JS already makes sure that joins are not
    executed, and the call to this function itself occurs under a conditional that checks the
    sparse bit.

- Instead of checking data bounds in the runtime and setting the sparse slot through code
  generated by Stack2JS, this is now simplified by doing it completely in the runtime with
  the functions
  - `updateSparseBitOnEntry(x: Level)`
  - `updateSparseBitOnReturn()`

- Use consistent naming: use "sparse bit" all places, instead of "bound slot" etc.
- Make code in Stack2JS less redundant