### PR TITLE
Sparsebit improvements

### DIFF
--- a/rt/src/builtins/UserRuntimeZero.mts
+++ b/rt/src/builtins/UserRuntimeZero.mts
@@ -92,20 +92,9 @@ export class UserRuntimeZero {
         this.runtime.ret (x)
     }
 
-    join (...xs) {
-        if (this.runtime.$t._isDataBoundByPC) {
-            return this.runtime.$t.pc 
-        } 
+    // SimpleRT
+    raw_join(...xs) : Level {
         return lub.apply (null, xs)
-    }
-
-    wrap_block_rhs (x) {
-        if (this.runtime.$t._isDataBoundByPC) {
-            return this.runtime.$t.bl 
-        } else {
-            return x;
-        }
-        
     }
 
     // SpecialRT


### PR DESCRIPTION
- Remove remainders from an earlier refactoring (the local variable `_isDataBoundByPC` is not used)
  - The check for this variable in UserRuntimeZero was thus always false
  - The variable was used in the runtime operation `join`, to only apply joins if data is not
    bounded by PC. However, the branching to avoid such joins is already inserted by Stack2JS,
    thus it is redundant here and probably a remainder from earlier refactoring.
  - The runtime function `wrap_block_rhs` is redundant. It was used in the context of updating
    the blocking label through code generated in Stack2JS. It just returned the label to set
    the blocking label to, if the sparse bit is not set, and the current blocking label otherwise.
    Again this optimization is unnecessary here, as Stack2JS already makes sure that joins are not
    executed, and the call to this function itself occurs under a conditional that checks the
    sparse bit.

- Instead of checking data bounds in the runtime and setting the sparse slot through code
  generated by Stack2JS, this is now simplified by doing it completely in the runtime with
  the functions
  - `updateSparseBitOnEntry(x: Level)`
  - `updateSparseBitOnReturn()`

- Use consistent naming: use "sparse bit" all places, instead of "bound slot" etc.
- Make code in Stack2JS less redundant