### PR TITLE
dx/relay logging

### DIFF
--- a/relay/.gitignore
+++ b/relay/.gitignore
@@ -1,2 +1,2 @@
-troupe-p2p-relay
 keys
+relay.mjs

--- a/relay/Makefile
+++ b/relay/Makefile
@@ -1,6 +1,20 @@
-start-relay:
+help:
+	cat README.md
+
+start: start/basic
+
+start/silent:
 	node relay.mjs
 
-generate-relay-key:  
+start/basic:
+	DEBUG=libp2p:circuit-relay:server node relay.mjs
+
+start/verbose:
+	DEBUG=libp2p:circuit-relay:server,libp2p:yamux:trace node relay.mjs
+
+keys:
 	mkdir -p keys
 	node $(TROUPE)/rt/built/p2p/mkid.mjs --privkeyfile=keys/relay.priv --idfile=keys/relay.id --verbose
+
+clean:
+	rm -rf keys

--- a/relay/Makefile
+++ b/relay/Makefile
@@ -12,9 +12,19 @@ start/basic:
 start/verbose:
 	DEBUG=libp2p:circuit-relay:server,libp2p:yamux:trace node relay.mjs
 
-keys:
+build: build/relay
+
+build/keys:
 	mkdir -p keys
 	node $(TROUPE)/rt/built/p2p/mkid.mjs --privkeyfile=keys/relay.priv --idfile=keys/relay.id --verbose
 
-clean:
+build/relay:
+	tsc
+
+clean: clean/keys clean/relay
+
+clean/keys:
 	rm -rf keys
+
+clean/relay:
+	rm relay.mjs

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,20 +1,28 @@
 # Troupe p2p Relay
 
 This example is adapted from libp2p's Go relay and since then ported to
-Javascript's p2p implementation.
+JavaScript's p2p implementation.
 
-## Generating Key
+## Build
+
+The relay is written in TypeScript. To compile it to JavaScript, such that it
+can run, please use the following *Make* target:
+
+```bash
+make build/relay
+```
 
 The relay needs a key pair to function; its public *id* has to be shared with
 the Troupe nodes via the `default_relays` variable in
-`rt/src/p2p/p2pconfig.mjs`. To generate this pair, use the corresponding *Make*
-target as follows:
+`rt/src/p2p/p2pconfig.mjs`. To generate this pair, use the corresponding target
+as follows:
 
 ```bash
-make keys
+make build/keys
 ```
 
-To remove the keys again, use the following *make target*:
+To remove the build artifact `relay.mjs` and the keys, use the following
+target:
 
 ```bash
 make clean
@@ -22,7 +30,7 @@ make clean
 
 ## How To Run
 
-To start the relay server, run the corresponding *make target* as follows:
+To start the relay server, run the corresponding *Make* target as follows:
 
 ```bash
 make start

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,17 +1,23 @@
 # Troupe p2p Relay
 
-This example is adapted from libp2p's Go relay and since then ported
-to Javascript's p2p implementation.
+This example is adapted from libp2p's Go relay and since then ported to
+Javascript's p2p implementation.
 
 ## Generating Key
 
-The relay needs a key pair to function; its public *id* has to be
-shared with the Troupe nodes via the `default_relays` variable in
-`rt/src/p2p/p2pconfig.mjs`. To generate this pair, use the
-corresponding *make target* as follows:
+The relay needs a key pair to function; its public *id* has to be shared with
+the Troupe nodes via the `default_relays` variable in
+`rt/src/p2p/p2pconfig.mjs`. To generate this pair, use the corresponding *Make*
+target as follows:
 
 ```bash
-make generate-relay-key
+make keys
+```
+
+To remove the keys again, use the following *make target*:
+
+```bash
+make clean
 ```
 
 ## How To Run
@@ -19,5 +25,19 @@ make generate-relay-key
 To start the relay server, run the corresponding *make target* as follows:
 
 ```bash
-make start-relay
+make start
+```
+
+This starts the server with `basic` logging, including the respective 'keep
+alive' messages sent from each Troupe node. To run silently, instead run
+
+```bash
+make start/silent
+```
+
+To start it with verbose information about all traffic, run the following
+target:
+
+```bash
+make start/verbose
 ```

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -2,6 +2,7 @@ import { noise } from '@chainsafe/libp2p-noise';
 import { yamux } from '@chainsafe/libp2p-yamux';
 import { mplex } from '@libp2p/mplex';
 import { webSockets } from '@libp2p/websockets';
+import { logger } from '@libp2p/logger'
 import { createLibp2p } from 'libp2p';
 import { circuitRelayServer } from 'libp2p/circuit-relay';
 import { identifyService } from 'libp2p/identify';
@@ -62,14 +63,18 @@ async function main () {
     }
   });
 
+  // HACK: Use 'libp2p' logger with the exact same logging 'address' as the one in
+  //       'js-libp2p/packages/transport-circuit-relay-v2/src/server/index.ts'.
+  const log = logger('libp2p:circuit-relay:server');
+
   // Log established connections
   const _CONNECT = 'peer:connect';
   await node.addEventListener(_CONNECT, async ({ detail }) => {
-    logTraffic(detail, _CONNECT);
+    log(`connection with ${detail} established`);
   });
   const _DISCONNECT = 'peer:disconnect';
   await node.addEventListener(_DISCONNECT, async ({ detail }) => {
-    logTraffic(detail, _DISCONNECT);
+    log(`disconnection from ${detail}`);
   });
 
   // Log 'keep alive' messages
@@ -78,7 +83,7 @@ async function main () {
     const src_id = connection.remotePeer;
 
     // Log start of 'keep alive' protocol
-    logTraffic(src_id, _RELAY_PROTOCOL, 'Relay handling protocol (keep-alives) initiated.');
+    log(`initiating keep alive protocol with ${src_id}`);
 
     // Log each 'keep alive' message to the console
     pipe(
@@ -87,7 +92,7 @@ async function main () {
       (source) => map(source, (buf) => uint8ArrayToString(buf.subarray())),
       async (source) => {
         for await (const msg of source) {
-          logTraffic(src_id, _RELAY_PROTOCOL, msg.toString());
+          log(`keep alive from ${src_id}: '${msg.toString()}'`);
         }
       }
     );
@@ -105,15 +110,10 @@ async function main () {
   //   To also log *all* traffic, also include '*libp2p:yamux:trace' in DEBUG.
 
   // Log set up of Relay node finished and its addresses.
-  console.log(`Relay node started with id ${node.peerId.toString()}`);
-  console.log('Listening on:');
-  node.getMultiaddrs().forEach((ma) => console.log(`  ${ma.toString()}`));
-  console.log('');
+  log(`Relay ready with id ${node.peerId.toString()}`);
+  log('Listening on:');
+  node.getMultiaddrs().forEach((ma) => log(`  ${ma.toString()}`));
+    console.log('');
 }
-
-const logTraffic = (id, protocol, msg) => {
-    console.log(`${(new Date()).toISOString()} [${id}]: ${protocol}`);
-    if (msg) { console.log(`  ${msg}`); }
-};
 
 main();

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -86,6 +86,7 @@ async function main () {
   console.log(`Relay node started with id ${node.peerId.toString()}`);
   console.log('Listening on:');
   node.getMultiaddrs().forEach((ma) => console.log(ma.toString()));
+  console.log('');
 }
 
 main();

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -66,7 +66,7 @@ async function main () {
     let id = connection.remotePeer;
     console.log(`Relay handling protocol, id: ${id}`);
     streamToConsole(stream, id);
-  })
+  });
 
   console.log(`Relay node started with id ${node.peerId.toString()}`);
   console.log('Listening on:');
@@ -87,4 +87,4 @@ function streamToConsole (stream, id) {
   );
 }
 
-main()
+main();

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -93,7 +93,16 @@ async function main () {
     );
   });
 
-  // TODO: Relayed messages
+  // TODO: Log relayed traffic
+  //
+  // NOTE:
+  //   For libp2p logging messages, please set the DEBUG environment variable to
+  //   'libp2p*' or 'libp2p:circuit-relay:*'. For example:
+  //
+  //   ```
+  //     DEBUG=libp2p:circuit-relay node relay.mjs
+  //   ```
+  //   To also log *all* traffic, also include '*libp2p:yamux:trace' in DEBUG.
 
   // Log set up of Relay node finished and its addresses.
   console.log(`Relay node started with id ${node.peerId.toString()}`);

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -62,29 +62,30 @@ async function main () {
     }
   });
 
+  // Log 'keep alive' messages
   await node.handle("/trouperelay/keepalive", async ({ connection, stream }) => {
-    let id = connection.remotePeer;
-    console.log(`Relay handling protocol, id: ${id}`);
-    streamToConsole(stream, id);
+    const id = connection.remotePeer;
+
+    // Log start of 'keep alive' protocol
+    console.log(`Relay handling protocol (keep-alives) from: ${id}`);
+
+    // Log each 'keep alive' message to the console
+    pipe(
+      stream.source,
+      (source) => lp.decode(source),
+      (source) => map(source, (buf) => uint8ArrayToString(buf.subarray())),
+      async (source) => {
+        for await (const msg of source) {
+          console.log(`Keep alive message from ${id}: ${msg.toString()}`);
+        }
+      }
+    );
   });
 
+  // Log set up of Relay node finished and its addresses.
   console.log(`Relay node started with id ${node.peerId.toString()}`);
   console.log('Listening on:');
   node.getMultiaddrs().forEach((ma) => console.log(ma.toString()));
-}
-
-function streamToConsole (stream, id) {
-  console.log(`Handling keep-alives from ${id}`);
-  pipe(
-    stream.source,
-    (source) => lp.decode(source),
-    (source) => map(source, (buf) => uint8ArrayToString(buf.subarray())),
-    async function (source) {
-      for await (const msg of source) {
-        console.log(`Keep alive message from ${id}: ${msg.toString()}`);
-      }
-    }
-  );
 }
 
 main();

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -62,12 +62,23 @@ async function main () {
     }
   });
 
+  // Log established connections
+  const _CONNECT = 'peer:connect';
+  await node.addEventListener(_CONNECT, async ({ detail }) => {
+    logTraffic(detail, _CONNECT);
+  });
+  const _DISCONNECT = 'peer:disconnect';
+  await node.addEventListener(_DISCONNECT, async ({ detail }) => {
+    logTraffic(detail, _DISCONNECT);
+  });
+
   // Log 'keep alive' messages
-  await node.handle("/trouperelay/keepalive", async ({ connection, stream }) => {
-    const id = connection.remotePeer;
+  const _RELAY_PROTOCOL = '/trouperelay/keepalive';
+  await node.handle(_RELAY_PROTOCOL, async ({ connection, stream }) => {
+    const src_id = connection.remotePeer;
 
     // Log start of 'keep alive' protocol
-    console.log(`Relay handling protocol (keep-alives) from: ${id}`);
+    logTraffic(src_id, _RELAY_PROTOCOL, 'Relay handling protocol (keep-alives) initiated.');
 
     // Log each 'keep alive' message to the console
     pipe(
@@ -76,17 +87,24 @@ async function main () {
       (source) => map(source, (buf) => uint8ArrayToString(buf.subarray())),
       async (source) => {
         for await (const msg of source) {
-          console.log(`Keep alive message from ${id}: ${msg.toString()}`);
+          logTraffic(src_id, _RELAY_PROTOCOL, msg.toString());
         }
       }
     );
   });
 
+  // TODO: Relayed messages
+
   // Log set up of Relay node finished and its addresses.
   console.log(`Relay node started with id ${node.peerId.toString()}`);
   console.log('Listening on:');
-  node.getMultiaddrs().forEach((ma) => console.log(ma.toString()));
+  node.getMultiaddrs().forEach((ma) => console.log(`  ${ma.toString()}`));
   console.log('');
 }
+
+const logTraffic = (id, protocol, msg) => {
+    console.log(`${(new Date()).toISOString()} [${id}]: ${protocol}`);
+    if (msg) { console.log(`  ${msg}`); }
+};
 
 main();

--- a/relay/relay.mjs
+++ b/relay/relay.mjs
@@ -42,7 +42,7 @@ async function main () {
           There is also no way to distinguish whether the relay cut off the connection
           because of a time/data limit or the other party cut off the connection. Therefore,
           it is impossible to know whether to re-establish the connection or not.
-          
+
           Two alternatives to giving large limits were considered.
           - The good solution
           Implement the connections being intentionally broken by the peers involved

--- a/relay/relay.mts
+++ b/relay/relay.mts
@@ -14,9 +14,9 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string';
 import { readFileSync } from 'fs';
 
 async function main () {
-  const relayId = readFileSync("keys/relay.id");
-  const relayKey = readFileSync("keys/relay.priv");
-  const id = await createFromJSON({id : relayId, privKey : relayKey});
+  const relayId  = readFileSync("keys/relay.id").toString();
+  const relayKey = readFileSync("keys/relay.priv").toString();
+  const id       = await createFromJSON({id : relayId, privKey : relayKey});
 
   const node = await createLibp2p({
     peerId : id,

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "outDir": "./",
+        "allowJs": false,
+        "moduleResolution": "node16",
+        "module": "Node16",
+        "target": "ES2022",
+        "esModuleInterop": true,
+        "incremental": false,
+    },
+    "include": ["./relay.mts"],
+    "exclude": []
+}


### PR DESCRIPTION
- Some small clean-up in `relay.mjs`.
- Converted `relay.mjs` to TypeScript.
- Switched to using `libp2p`'s own logging framework; maybe this is something to be used for the Troupe nodes as well?
  - Add logging of `peer:connect` and `peer:disconnect`
  - Logging each individual message between peers does not seem possible without quite a bit of a hack. One would probably have to overwrite the `/libp2p/circuit/relay/0.2.0/hop` protocol handler to interject some logging before using the original code. Yet, this would create a dependency on *private* functions within the [`CircuitRelayServer`](https://github.com/libp2p/js-libp2p/blob/main/packages/transport-circuit-relay-v2/src/server/index.ts#L178) which would be a nightmare to maintain. Yet, `libp2p` also provides logging of everything that goes through the streams(ish). So, while it is not pretty one can now see in the logs whether the relay is used or not.
  - Since relayed messages are not logged, should the `keep alive` messages still be?

Here is a picture of the log output (without verbose all-traffic logging):

![image](https://github.com/user-attachments/assets/579e2160-7681-4b8e-9c03-757f13634698)