### PR TITLE
Fix single quotes (') cannot be used as field variable in exported lib structs

### DIFF
--- a/compiler/src/Stack2JS.hs
+++ b/compiler/src/Stack2JS.hs
@@ -560,7 +560,7 @@ ppSparseSlot = do
 fieldToJS :: ToJS a => (String, a) -> W PP.Doc
 fieldToJS (f, v) = do 
     d <- toJS v 
-    return $ PP.brackets $ PP.quotes (text f) <> text "," <> d
+    return $ PP.brackets $ PP.doubleQuotes (text f) <> text "," <> d
 
 fieldsToJS :: ToJS a => [(String, a)] -> W [PP.Doc]
 fieldsToJS fs = do 


### PR DESCRIPTION
Unlike the single quotes, the double quotes (") is not a valid symbol as part of an SML variable. Yet, it is also a valid string-syntax and so we can use it instead of single quotes without having to begin escaping any characters.

Closes #59 .

**Dependencies**

- #61