### PR TITLE
Rename `Call` to `StackExpand`

### DIFF
--- a/compiler/src/ClosureConv.hs
+++ b/compiler/src/ClosureConv.hs
@@ -201,7 +201,7 @@ cpsToIR (CPS.LetSimple vname@(VN ident) st kt) = do
 cpsToIR (CPS.LetRet (CPS.Cont arg kt') kt) = do
     t  <- cpsToIR kt
     t' <- local (insVar arg) (cpsToIR kt')
-    return $ CCIR.BB [] $ Call arg t t'
+    return $ CCIR.BB [] $ StackExpand arg t t'
 cpsToIR (CPS.LetFun fdefs kt) = do 
     let vnames_orig = map (\(CPS.Fun fname _) -> fname) fdefs
     let localExt = local (insVars vnames_orig)

--- a/compiler/src/IR.hs
+++ b/compiler/src/IR.hs
@@ -91,7 +91,7 @@ data IRTerminator
   -- and then execute the second BB, which can refer to this variable and
   -- where PC is reset to the level before entering the first BB.
   -- Represents a "let x = ... in ..." format.
-  | Call VarName IRBBTree IRBBTree
+  | StackExpand VarName IRBBTree IRBBTree
   deriving (Eq,Show,Generic)
 
 
@@ -147,7 +147,7 @@ instance ComputesDependencies IRBBTree where
 instance ComputesDependencies IRTerminator where 
     dependencies (If _ bb1 bb2) = mapM_ dependencies [bb1, bb2]
     dependencies (AssertElseError _ bb1 _ _) = dependencies bb1
-    dependencies (Call _ t1 t2) = dependencies t1  >> dependencies t2
+    dependencies (StackExpand _ t1 t2) = dependencies t1  >> dependencies t2
 
     dependencies _              = return ()
 instance ComputesDependencies FunDef where
@@ -231,15 +231,15 @@ instance WellFormedIRCheck IRInst where
  wfir (Assign (VN x) e) = do checkId x
                              wfir e
  wfir (MkFunClosures _ fdefs) = mapM_ (\((VN x), _) -> checkId x) fdefs
- 
+
 
 instance WellFormedIRCheck IRTerminator where
   wfir (If _ bb1 bb2) = do
     wfir bb1
     wfir bb2
   wfir (AssertElseError _ bb _ _) = wfir bb
-  wfir (Call (VN x) bb1 bb2 ) = do 
-    checkId x 
+  wfir (StackExpand (VN x) bb1 bb2 ) = do
+    checkId x
     wfir bb1
     wfir bb2
 
@@ -442,7 +442,8 @@ ppIR (MkFunClosures varmap fdefs) =
 
     
 
-ppTr (Call vn bb1 bb2) = (ppId vn <+> text "= call" $$ nest 2 (ppBB bb1)) $$ (ppBB bb2)
+
+ppTr (StackExpand vn bb1 bb2) = (ppId vn <+> text "= call" $$ nest 2 (ppBB bb1)) $$ (ppBB bb2)
 
 
 ppTr (AssertElseError va ir va2 _) 

--- a/compiler/src/IR2Raw.hs
+++ b/compiler/src/IR2Raw.hs
@@ -699,7 +699,7 @@ tr2raw = \case
     return $ If r bb1' bb2'
 
   -- Revision 2023-08: Equivalent, only way of modifying bb2 changed.
-  IR.Call v irBB1 irBB2 -> do
+  IR.StackExpand v irBB1 irBB2 -> do
     bb1 <- tree2raw irBB1
     BB insts2 tr2 <- tree2raw irBB2
     -- Prepend before insts2 instructions to store in variable v the result
@@ -711,7 +711,7 @@ tr2raw = \case
                                   -- generally using Sequence (faster concatenation) for instructions
                                   -- might improve performance
     let bb2 = BB insts2' tr2
-    return $ Call bb1 bb2
+    return $ StackExpand bb1 bb2
 
   -- Note: This is translated into branching and Error for throwing RT exception
   -- Revision 2023-08: More fine-grained raising of blocking label, see below.

--- a/compiler/src/IROpt.hs
+++ b/compiler/src/IROpt.hs
@@ -67,7 +67,7 @@ instance Substitutable IRTerminator where
                 AssertElseError (apply subst x) (apply subst bb) (apply subst y) pos 
             LibExport x -> LibExport (apply subst x)
             Error x pos -> Error (apply subst x) pos 
-            Call decVar bb1 bb2 -> Call decVar (apply subst bb1) (apply subst bb2)
+            StackExpand decVar bb1 bb2 -> StackExpand decVar (apply subst bb1) (apply subst bb2)
 
 instance Substitutable IRBBTree where 
     apply subst (BB insts tr) = 
@@ -462,7 +462,7 @@ trPeval (AssertElseError x bb y_err pos) = do
                 return $ BB [] (AssertElseError x bb' y_err pos)     
 
 
-trPeval (Call x bb1 bb2) = do 
+trPeval (StackExpand x bb1 bb2) = do 
     bb1' <- peval bb1 
     bb2' <- peval bb2
 
@@ -473,7 +473,7 @@ trPeval (Call x bb1 bb2) = do
             setChangeFlag           
             return $ BB (insts1 ++ insts2) tr2
         _ -> 
-            return $ BB [] (Call x bb1' bb2')
+            return $ BB [] (StackExpand x bb1' bb2')
 
 trPeval tr@(Ret x) = do 
     markUsed' x 

--- a/compiler/src/Raw.hs
+++ b/compiler/src/Raw.hs
@@ -158,7 +158,7 @@ data RawTerminator
   | Error RawVar PosInf
   -- | Execute the first BB and then execute the second BB where
   -- PC is reset to the level before entering the first BB.
-  | Call RawBBTree RawBBTree
+  | StackExpand RawBBTree RawBBTree
   deriving (Eq, Show)
 
 
@@ -341,7 +341,7 @@ ppIR (MkFunClosures varmap fdefs) =
 -- ppIR (LevelOperations _ insts) = 
 --  text "level operation" $$ nest 2 (vcat (map ppIR insts))
 
-ppTr (Call bb1 bb2) = (text "call" $$ nest 4 (ppBB bb1)) $$ (ppBB bb2)
+ppTr (StackExpand bb1 bb2) = (text "call" $$ nest 4 (ppBB bb1)) $$ (ppBB bb2)
 
 
 -- ppTr (AssertElseError va ir va2 _) 

--- a/compiler/src/Raw2Stack.hs
+++ b/compiler/src/Raw2Stack.hs
@@ -188,7 +188,7 @@ trTr (Raw.LibExport v) = do
      return $ Stack.LibExport v 
 trTr (Raw.Error r1 p) = do 
      return $ Stack.Error r1 p 
-trTr (Raw.Call bb1 bb2) = do 
+trTr (Raw.StackExpand bb1 bb2) = do 
    __callDepth <- localCallDepth <$> ask 
    bb1' <- local (\tenv -> tenv { localCallDepth = __callDepth + 1 } ) $ trBB bb1 
    n <- getBlockNumber
@@ -205,7 +205,7 @@ trTr (Raw.Call bb1 bb2) = do
                     | x <-  filter filterConsts (Set.elems varsToLoad) ]   
    bb2'@(Stack.BB inst_2 tr_2) <- trBB bb2
 
-   return $ Stack.Call bb1' (Stack.BB (loads ++ inst_2) tr_2)
+   return $ Stack.StackExpand bb1' (Stack.BB (loads ++ inst_2) tr_2)
 
 
 trBB :: Raw.RawBBTree -> Tr Stack.StackBBTree 

--- a/compiler/src/RawDefUse.hs
+++ b/compiler/src/RawDefUse.hs
@@ -233,7 +233,7 @@ instance Trav RawTerminator where
          trav bb2
        LibExport v -> use v 
        Error r _ -> use r 
-       Call bb1 bb2 -> do
+       StackExpand bb1 bb2 -> do
          trav bb1
          modify (\s -> 
                      let (c, _) = locInfo s 

--- a/compiler/src/RawOpt.hs
+++ b/compiler/src/RawOpt.hs
@@ -78,7 +78,7 @@ instance Substitutable RawTerminator where
       If r bb1 bb2 -> 
         If (apply subst r) (apply subst bb1) (apply subst bb2)
       Error r p -> Error (apply subst r) p 
-      Call bb1 bb2 -> Call (apply subst bb1) (apply subst bb2) 
+      StackExpand bb1 bb2 -> StackExpand (apply subst bb1) (apply subst bb2) 
       _ -> tr
 
 instance Substitutable RawBBTree where
@@ -420,7 +420,7 @@ instance PEval RawTerminator where
                 }
         bb2' <- peval bb2         
         return $ If x bb1' bb2'
-      Call bb1 bb2 -> do
+      StackExpand bb1 bb2 -> do
         s <- get
         bb1' <- peval bb1
         put $ s { stateMon = Map.empty
@@ -428,7 +428,7 @@ instance PEval RawTerminator where
                 , stateJoins = stateJoins s 
                 } -- reset the monitor state
         bb2' <- peval bb2
-        return $ Call bb1' bb2'
+        return $ StackExpand bb1' bb2'
       Ret -> do 
         return tr' 
       TailCall x -> do 
@@ -470,14 +470,15 @@ filterInstBwd ls =
   f (Nothing, Nothing) (reverse ls) []
 
 
--- | This optimization for 'Call' moves instructions from the continuation to before the 'Call'.
--- This can result in a 'Call' which just contains a 'Ret', which is then optimized away.
--- The optimization compensates for redundant assignments introduced by the translation.
-hoistCalls :: RawBBTree -> RawBBTree
-hoistCalls bb@(BB insts tr) = 
+-- | This optimization for 'StackExpand' moves instructions from the continuation to before the
+-- 'StackExpand'. This can result in a 'StackExpand' which just contains a 'Ret', which is then
+-- optimized away. The optimization compensates for redundant assignments introduced by the
+-- translation.
+hoistStackExpand :: RawBBTree -> RawBBTree
+hoistStackExpand bb@(BB insts tr) = 
   case tr of 
     -- Here we check which instructions from ii_1 can be moved to before the call
-    Call (BB ii_1 tr_1) bb2 ->
+    StackExpand (BB ii_1 tr_1) bb2 ->
       let isFrameSpecific i = 
             case i of 
               SetBranchFlag -> True
@@ -487,7 +488,7 @@ hoistCalls bb@(BB insts tr) =
           -- jx_1: non-frame-specific instructions, are moved to before the call
           -- jx_2: frame-specific instructions, stay under the call's instructions
           (jx_1, jx_2)  = Data.List.break isFrameSpecific ii_1  
-      in BB (insts ++ jx_1) (Call (BB jx_2 tr_1) bb2) 
+      in BB (insts ++ jx_1) (StackExpand (BB jx_2 tr_1) bb2) 
     -- If returning, the current frame will be removed, and thus all PC set instructions
     -- are redundant and can be removed.
     Ret -> 
@@ -537,7 +538,7 @@ instance PEval RawBBTree where
                 If x (BB (set_pc_bl ++ i_then) tr_then) 
                      (BB (set_pc_bl ++ i_else) tr_else)
  
-            _ -> hoistCalls $ BB (insts_no_ret ++ set_pc_bl) tr''
+            _ -> hoistStackExpand $ BB (insts_no_ret ++ set_pc_bl) tr''
     let insts_sorted = instOrder insts_ 
     return $ BB insts_sorted bb_
   

--- a/compiler/src/Stack.hs
+++ b/compiler/src/Stack.hs
@@ -47,7 +47,7 @@ data StackTerminator
   | If RawVar StackBBTree StackBBTree
   | LibExport VarAccess
   | Error RawVar PosInf
-  | Call  StackBBTree StackBBTree
+  | StackExpand  StackBBTree StackBBTree
   deriving (Eq, Show)
 
 
@@ -150,7 +150,7 @@ ppIR (MkFunClosures varmap fdefs) =
 ppIR (LabelGroup insts) = 
  text "group" $$ nest 2 (vcat (map ppIR insts))
 
-ppTr (Call bb1 bb2) = (text "= call" $$ nest 2 (ppBB bb1)) $$ (ppBB bb2)
+ppTr (StackExpand bb1 bb2) = (text "= call" $$ nest 2 (ppBB bb1)) $$ (ppBB bb2)
 
 
 -- ppTr (AssertElseError va ir va2 _) 

--- a/compiler/src/Stack2JS.hs
+++ b/compiler/src/Stack2JS.hs
@@ -452,7 +452,7 @@ ir2js InvalidateSparseBit = return $
 {-- TERMINATORS --}
 
 
-tr2js (Call bb bb2) = do
+tr2js (StackExpand bb bb2) = do
     _frameSize <- gets frameSize
     _sparseSlot <- gets sparseSlot
     _consts <- gets consts

--- a/compiler/test/ir2raw-test/testcases/TR.hs
+++ b/compiler/test/ir2raw-test/testcases/TR.hs
@@ -30,8 +30,8 @@ tcs = map (second mkP)
        (BB [Assign (VN "b1") (Base "v1") ] (LibExport (mkV "b1")))
        (BB [Assign (VN "b2") (Base "v2") ] (LibExport (mkV "b2")))
   ),
-  ( "Call"
-  , Call (VN "x")
+  ( "StackExpand"
+  , StackExpand (VN "x")
        (BB [Assign (VN "b1") (Base "v1") ] (LibExport (mkV "b1")))
        (BB [Assign (VN "b2") (Base "v2") ] (LibExport (mkV "b2")))
   ),


### PR DESCRIPTION
As mentioned at our meeting this last monday: `Call` should be renamed to `StackExpand` to better convey its meaning.