### PR TITLE
Improve lib record export syntax

### DIFF
--- a/lib/Hash.trp
+++ b/lib/Hash.trp
@@ -68,15 +68,13 @@ let
 
     (*--- Module ---*)
     val Hash = {
-        hashString        = hashString,
-        hashMultiplyShift = hashMultiplyShift,
-        hashInt           = hashInt,
-        hashNumber        = hashNumber,
-        hashList          = hashList,
-        hash              = hash
+        hashString,
+        hashMultiplyShift,
+        hashInt,
+        hashNumber,
+        hashList,
+        hash
     }
 
-in [ ("Hash", Hash)
-   , ("hash", hash)
-   ]
+in [ ("Hash", Hash), ("hash", hash) ]
 end

--- a/lib/HashMap.trp
+++ b/lib/HashMap.trp
@@ -202,24 +202,20 @@ let (* NOTE: The map is implemented as a Hash Array Mapped Trie (HAMT), i.e. a p
 
     (*--- Module ---*)
     val HashMap = {
-        (* Construction *)
-        empty     = empty,
-        singleton = singleton,
-        insert    = insert,
-        remove    = remove,
-        (* Queries *)
-        null      = null,
-        size      = size,
-        findOpt   = findOpt,
-        find      = find,
-        mem       = mem,
-        (* Manipulation *)
-        fold      = fold,
-        (* List Conversion*)
-        keys      = keys,
-        values    = values,
-        toList    = toList,
-        fromList  = fromList
+        empty,
+        singleton,
+        insert,
+        remove,
+        null,
+        size,
+        findOpt,
+        find,
+        mem,
+        fold,
+        keys,
+        values,
+        toList,
+        fromList
     }
 
 in [ ("HashMap", HashMap) ]

--- a/lib/HashSet.trp
+++ b/lib/HashSet.trp
@@ -47,21 +47,17 @@ let (* NOTE: The set is implemented as a HashMap with dummy values, `()`. This i
 
     (*--- Module ---*)
     val HashSet = {
-        (* Construction *)
-        empty     = empty,
-        singleton = singleton,
-        insert    = insert,
-        remove    = remove,
-        (* Queries *)
-        null      = null,
-        size      = size,
-        mem       = mem,
-        (* Manipulation *)
-        fold      = fold,
-        (* List Conversion*)
-        elems     = elems,
-        toList    = toList,
-        fromList  = fromList
+        empty,
+        singleton,
+        insert,
+        remove,
+        null,
+        size,
+        mem,
+        fold,
+        elems,
+        toList,
+        fromList
     }
 
 in [ ("HashSet", HashSet) ]

--- a/lib/List.trp
+++ b/lib/List.trp
@@ -169,33 +169,26 @@ let (* -- List Access -- *)
 
     (*--- Module ---*)
     val List = {
-        head      = head,
-        tail      = tail,
-        nth       = nth,
-
-        null      = null,
-        elem      = elem,
-        length    = length,
-
-        reverse   = reverse,
-        append    = append,
-        revAppend = revAppend,
-        appendAt  = appendAt,
-        sublist   = sublist,
-
-        map       = map,
-        mapi      = mapi,
-        foldl     = foldl,
-        filter    = filter,
-        filteri   = filteri,
-        partition = partition,
-
-        range     = range,
-
-        sort      = sort
+        head,
+        tail,
+        nth,
+        null,
+        elem,
+        length,
+        reverse,
+        append,
+        revAppend,
+        appendAt,
+        sublist,
+        map,
+        mapi,
+        foldl,
+        filter,
+        filteri,
+        partition,
+        range,
+        sort
     }
 
-in [ ("List", List),
-     ("length", length)
-   ]
+in [ ("List", List), ("length", length) ]
 end

--- a/lib/ListPair.trp
+++ b/lib/ListPair.trp
@@ -64,22 +64,19 @@ let (* -- ListPair Generation -- *)
 
     (*--- Module ---*)
     val ListPair = {
-        zip       = zip,
-        unzip     = unzip,
-
-        null      = null,
-        length    = length,
-
-        reverse   = reverse,
-        append    = append,
-        revAppend = revAppend,
-
-        findOpt   = findOpt,
-        find      = find,
-        mem       = mem,
-
-        map       = map,
-        foldl     = foldl
+        zip,
+        unzip,
+        null,
+        length,
+        reverse,
+        append,
+        revAppend,
+        findOpt,
+        find,
+        mem,
+        map,
+        foldl
     }
 
-in [ ("ListPair", ListPair) ] end
+in [ ("ListPair", ListPair) ]
+end

--- a/lib/Number.trp
+++ b/lib/Number.trp
@@ -93,25 +93,26 @@ let (** Largest (safe) possible integral value. Anything larger than this cannot
 
     (*--- Module ---*)
     val Number = {
-        maxInt     = maxInt,
-        minInt     = minInt,
-        precision  = precision,
-        maxInt32   = maxInt32,
-        minInt32   = minInt32,
-        maxNum     = maxNum,
-        minNum     = minNum,
-        abs        = abs,
-        min        = min,
-        max        = max,
-        ceil       = ceil,
-        floor      = floor,
-        round      = round,
-        sqrt       = sqrt,
-        isInt      = isInt,
-        toInt      = toInt,
-        toInt32    = toInt32,
-        toString   = toString,
-        fromString = fromString
+        maxInt,
+        minInt,
+        precision,
+        maxInt32,
+        minInt32,
+        maxNum,
+        minNum,
+        abs,
+        min,
+        max,
+        ceil,
+        floor,
+        round,
+        sqrt,
+        isInt,
+        toInt,
+        toInt32,
+        toString,
+        fromString
     }
+
 in [("Number", Number)]
 end

--- a/lib/StencilVector.trp
+++ b/lib/StencilVector.trp
@@ -146,26 +146,24 @@ let (*--- Constants ---*)
 
     (* TODO: Lift list functions `mapi`, `find` and `filter`? *)
 
+    (*--- Module ---*)
     val StencilVector = {
-        (* Constants *)
-        maskBits     = maskBits,
-        maskMax      = maskMax,
-        (* Functions *)
-        empty        = empty,
-        singleton    = singleton,
-        get          = get,
-        getOrDefault = getOrDefault,
-        set          = set,
-        unset        = unset,
-        mem          = mem,
-        valid        = valid,
-        null         = null,
-        mask         = mask,
-        length       = length,
-        map          = map,
-        fold         = fold
+        maskBits,
+        maskMax,
+        empty,
+        singleton,
+        get,
+        getOrDefault,
+        set,
+        unset,
+        mem,
+        valid,
+        null,
+        mask,
+        length,
+        map,
+        fold
     }
-in  (* Export public functions *)
-    [ ("StencilVector", StencilVector)
-    ]
+
+in [ ("StencilVector", StencilVector) ]
 end

--- a/lib/String.trp
+++ b/lib/String.trp
@@ -70,17 +70,18 @@ let (** The maximum length of a string.
 
     (*--- Module ---*)
     val String = {
-        maxSize    = maxSize,
-        size       = size,
-        sub        = sub,
-        subCode    = subCode,
-        substring  = substring,
-        concat     = concat,
-        concatWith = concatWith,
-        implode    = implode,
-        explode    = explode,
-        map        = map,
-        translate  = translate
+        maxSize,
+        size,
+        sub,
+        subCode,
+        substring,
+        concat,
+        concatWith,
+        implode,
+        explode,
+        map,
+        translate
     }
+
 in [("String", String)]
 end

--- a/lib/Unit.trp
+++ b/lib/Unit.trp
@@ -112,13 +112,13 @@ let
 
     (*--- Module ---*)
     val Unit = {
-        group   = group,
-        it      = it,
-        isEq    = isEq,
-        isTrue  = isTrue,
-        isFalse = isFalse,
-        isNeq   = isNeq,
-        run     = run
+        group,
+        it,
+        isEq,
+        isTrue,
+        isFalse,
+        isNeq,
+        run
     }
 
 in [ ("Unit", Unit) ]


### PR DESCRIPTION
This way, it is less likely one by accident exports the wrong function under a different name