### PR TITLE
Set up Dependabot to keep an eye on Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Once a week, there might be incoming pull requests should some dependency in the `.github` folder not be up to date.