### PR TITLE
feat: add a CLOC definition of Troupe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,14 @@ test/ci-relay: p2p-tools
 	@echo "Running CI relay test..."
 	./tests/ci-relay-test.sh
 
+CLOC_DIR=.
+cloc:
+	cloc --read-lang-def=cloc.txt $(CLOC_DIR)
+cloc/lib:
+	$(MAKE) cloc CLOC_DIR=lib
+cloc/test:
+	$(MAKE) cloc CLOC_DIR=tests
+
 dist: stack npm rt p2p-tools lib
 	rm -rf ./build/
 	mkdir -p ./build/Troupe/rt/built

--- a/cloc.txt
+++ b/cloc.txt
@@ -1,0 +1,6 @@
+Troupe
+    filter remove_between_general (* *)
+    extension trp
+    extension pico
+    extension picox
+    3rd_gen_scale 3.00


### PR DESCRIPTION
I cannot tell whether this should be placed in a separate repository, `TroupeLang/cloc`, or here. Either way, this makes sure we have documented how to count lines of code of Troupe code.