### PR TITLE
feat: `sha256` builtin

### DIFF
--- a/compiler/src/IR.hs
+++ b/compiler/src/IR.hs
@@ -330,6 +330,8 @@ instance WellFormedIRCheck IRExpr where
                      , "_servicetest"
                      , "_setProcessDebuggingName"
                      , "_setFailureRate"
+                     , "sha256"
+                     , "sha256L"
                      , "sleep"
                      , "spawn"
                      , "sqrt"

--- a/rt/src/UserRuntime.mts
+++ b/rt/src/UserRuntime.mts
@@ -27,6 +27,7 @@ import { BuiltinSandbox } from './builtins/sandbox.mjs'
 import { BuiltinLocalArrays } from './builtins/localarrays.mjs'
 import { RuntimeAssert } from './builtins/runtimeassert.mjs'
 import { BuiltinService } from './builtins/service.mjs'
+import { BuiltinHash } from './builtins/hash.mjs'
 import { BuiltinString } from './builtins/string.mjs'
 import { BuiltinRecordReflection } from './builtins/recordReflection.mjs'
 import { BuiltinTypeInformation } from './builtins/types.mjs'
@@ -48,6 +49,7 @@ export const UserRuntime =
     BuiltSpawnSendReceive(
     BuiltinStringToInt(
     BuiltinToString(
+    BuiltinHash(
     BuiltinGetTime(
     BuiltinAdv(
     BuiltinExit(
@@ -64,5 +66,5 @@ export const UserRuntime =
     BuiltinMath(
     BuiltinRecordReflection(
     BuiltinTypeInformation(
-    BuiltinStdIo(UserRuntimeZero)    
-    )))))))))))))))))))))))))))))
+    BuiltinStdIo(UserRuntimeZero)
+    ))))))))))))))))))))))))))))));

--- a/rt/src/builtins/hash.mts
+++ b/rt/src/builtins/hash.mts
@@ -1,0 +1,21 @@
+'use strict'
+import { UserRuntimeZero, Constructor, mkBuiltin } from './UserRuntimeZero.mjs'
+import { LVal } from '../base/LVal.mjs';
+import { hash } from '../base/lvalUtil.mjs';
+
+
+export function BuiltinHash<TBase extends Constructor<UserRuntimeZero>>(Base: TBase) {
+    return class extends Base {
+        sha256 = mkBuiltin((arg: LVal) => {
+            const h = hash(arg, { omitLevels: true });
+            const r = this.runtime.$t.mkCopy(h);
+            return this.runtime.ret(r);
+        }, "hash");
+
+        sha256L = mkBuiltin((arg: LVal) => {
+            const h = hash(arg);
+            const r = this.runtime.$t.mkCopy(h);
+            return this.runtime.ret(r);
+        }, "hashL");
+    }
+}

--- a/rt/src/hash.mts
+++ b/rt/src/hash.mts
@@ -1,0 +1,88 @@
+import { createHash, BinaryToTextEncoding } from 'node:crypto';
+
+import { TroupeType } from './TroupeTypes.mjs';
+import { LVal } from './Lval.mjs';
+import { BOT } from './Level.mjs';
+
+type HashAlgorithm = "sha256";
+
+type HashOptions = {
+    algorithm?: HashAlgorithm,
+    omitLevels?: boolean,
+};
+
+/** Hash a Troupe runtime value.
+ *
+ * @param x
+ *    The labelled value (`LVal`) to be hashed.
+ * @param omitLevels
+ *    Whether the levels should be omitted from the hash.
+ */
+export function hash(x: LVal/*<any>*/,
+                     { algorithm = "sha256", omitLevels = false }: HashOptions = {}
+                    ): LVal/*<string>*/
+{
+    const encoding: BinaryToTextEncoding = "base64";
+
+    switch (x.troupeType) {
+    // JavaScript basic types
+    case TroupeType.BOOLEAN:
+    case TroupeType.NUMBER:
+    case TroupeType.STRING:
+        // Treat the same way as Troupe basic types
+
+    // Troupe basic types
+    case TroupeType.UNIT:
+    case TroupeType.PROCESS_ID:
+    case TroupeType.LEVEL:
+    case TroupeType.AUTHORITY:
+    case TroupeType.CAPABILITY:
+    case TroupeType.ATOM:
+        // Since the `LVal::stringRep()` includes type information, e.g. `"`
+        // around strings, we can merely hash the value's string
+        // representation.
+        const taintRef = { lev: BOT };
+        const hasher = createHash(algorithm);
+        hasher.update(x.stringRep(omitLevels, taintRef));
+        return new LVal(hasher.digest(encoding), taintRef.lev, BOT);
+
+    // Troupe function type (closure)
+    case TroupeType.CLOSURE:
+        // TODO (SS; 2025-12-04): For closures, we need to hash the source
+        //                        code in some way, i.e., the IR string.
+        throw new Error(`hash(x: TroupeClosure) requires hashing the IR`);
+
+    // Troupe local object
+    case TroupeType.LOCALOBJECT:
+        // TODO (SS; 2025-12-05): What should we do for local objects?
+        throw new Error(`hash(x: LocalObject) is not hasheable`)
+
+    // Troupe aggregate types
+    default:
+        // TODO (SS; 2025-12-04): The above `stringRep()` approach does not
+        //                        work for aggregate types since records do
+        //                        not have their keys sorted.
+        throw new Error(`hash(x) not implemented for type ${x.troupeType}`);
+    }
+}
+
+export function isHasheable(x: LVal): boolean {
+    switch (x.troupeType) {
+    // Troupe function type (closure)
+    case TroupeType.CLOSURE:
+        return false;
+
+    // Troupe aggregate types
+    case TroupeType.TUPLE:
+    case TroupeType.LIST:
+    case TroupeType.RECORD:
+        return false;
+
+    // Troupe local objects
+    case TroupeType.LOCALOBJECT:
+        return false;
+
+    default:
+        return true;
+    }
+}

--- a/tests/rt/pos/core/sha256-authority.golden
+++ b/tests/rt/pos/core/sha256-authority.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:14.972Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "03k5cwae+U1YAzDVmpxqABXaAndYxMCPSc0EtQi9VEQ="@{}%{}

--- a/tests/rt/pos/core/sha256-authority.trp
+++ b/tests/rt/pos/core/sha256-authority.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 authority

--- a/tests/rt/pos/core/sha256-boolean00.golden
+++ b/tests/rt/pos/core/sha256-boolean00.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:16.388Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "/LzxZZCN0YqeSff/J4EBdtuOn2O0NSITdBZkJFIk+Ko="@{}%{}

--- a/tests/rt/pos/core/sha256-boolean00.trp
+++ b/tests/rt/pos/core/sha256-boolean00.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 false

--- a/tests/rt/pos/core/sha256-boolean01.golden
+++ b/tests/rt/pos/core/sha256-boolean01.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:15.583Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "tb6kG2xiP3wJ8b8k3K5Y66s8DN2QrZZrxDpFtEhn4Ss="@{}%{}

--- a/tests/rt/pos/core/sha256-boolean01.trp
+++ b/tests/rt/pos/core/sha256-boolean01.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 true

--- a/tests/rt/pos/core/sha256-number01.golden
+++ b/tests/rt/pos/core/sha256-number01.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:14.765Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "c0dctApWjo2ooEXO0RATfhWfiQrE2og7axfcZRs6gEk="@{}%{}

--- a/tests/rt/pos/core/sha256-number01.trp
+++ b/tests/rt/pos/core/sha256-number01.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 42

--- a/tests/rt/pos/core/sha256-number02.golden
+++ b/tests/rt/pos/core/sha256-number02.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:15.353Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "X+zrZv/IbzjZUnhsbWlsecLbwjndTpG0ZynXOif7V+k="@{}%{}

--- a/tests/rt/pos/core/sha256-number02.trp
+++ b/tests/rt/pos/core/sha256-number02.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 0

--- a/tests/rt/pos/core/sha256-string01.golden
+++ b/tests/rt/pos/core/sha256-string01.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:12.429Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "+5uleio8LM4dHWUcu7G1do/Mosyoe7aYee/5s9hm7MA="@{}%{}

--- a/tests/rt/pos/core/sha256-string01.trp
+++ b/tests/rt/pos/core/sha256-string01.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "Hello, Troupe!"

--- a/tests/rt/pos/core/sha256-string02.golden
+++ b/tests/rt/pos/core/sha256-string02.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:12.084Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "mYtPYDxzHVL3d876Ap6ZRM1n93NA9dS+TyWR0grTLo0="@{alice}%{}

--- a/tests/rt/pos/core/sha256-string02.trp
+++ b/tests/rt/pos/core/sha256-string02.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 ("Hello, Secret!" raisedTo `{alice}`)

--- a/tests/rt/pos/core/sha256-string03.golden
+++ b/tests/rt/pos/core/sha256-string03.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:13.276Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "mYtPYDxzHVL3d876Ap6ZRM1n93NA9dS+TyWR0grTLo0="@{bob}%{}

--- a/tests/rt/pos/core/sha256-string03.trp
+++ b/tests/rt/pos/core/sha256-string03.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 ("Hello, Secret!" raisedTo `{bob}`)

--- a/tests/rt/pos/core/sha256-string04.golden
+++ b/tests/rt/pos/core/sha256-string04.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:14.652Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "7S1V21jM/s/kkU/enNCB1aJigcEq8ilPZJqIMBynPcQ="@{}%{}

--- a/tests/rt/pos/core/sha256-string04.trp
+++ b/tests/rt/pos/core/sha256-string04.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "()"

--- a/tests/rt/pos/core/sha256-string05.golden
+++ b/tests/rt/pos/core/sha256-string05.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:15.815Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "gzTFVMcnb1lnSBC5L/9Rl81Gv2zL6HJ0L5sEyjHf49E="@{}%{}

--- a/tests/rt/pos/core/sha256-string05.trp
+++ b/tests/rt/pos/core/sha256-string05.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "42"

--- a/tests/rt/pos/core/sha256-string06.golden
+++ b/tests/rt/pos/core/sha256-string06.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:15.894Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "mAiebTb3jpdmyeo01ayzYR86ks2BxesQIJXZJP/H0Is="@{}%{}

--- a/tests/rt/pos/core/sha256-string06.trp
+++ b/tests/rt/pos/core/sha256-string06.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "0"

--- a/tests/rt/pos/core/sha256-string07.golden
+++ b/tests/rt/pos/core/sha256-string07.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:15.963Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "B23m5zDfC0w4YId6D2GcasEfiu/XgxOseToqcDwCaGk="@{}%{}

--- a/tests/rt/pos/core/sha256-string07.trp
+++ b/tests/rt/pos/core/sha256-string07.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "false"

--- a/tests/rt/pos/core/sha256-string08.golden
+++ b/tests/rt/pos/core/sha256-string08.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:16.635Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "GNEMfStLBKrwQlTRrl1lWl3AQHy83VqMOYbphTcPNu4="@{}%{}

--- a/tests/rt/pos/core/sha256-string08.trp
+++ b/tests/rt/pos/core/sha256-string08.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 "true"

--- a/tests/rt/pos/core/sha256-twice.trp
+++ b/tests/rt/pos/core/sha256-twice.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+(sha256 (), sha256 42)

--- a/tests/rt/pos/core/sha256-unit.golden
+++ b/tests/rt/pos/core/sha256-unit.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:14.461Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "LjjneyLDFKRJ6R+v7ZKkOCasaqQDrmqKy2z1gjn7r10="@{}%{}

--- a/tests/rt/pos/core/sha256-unit.trp
+++ b/tests/rt/pos/core/sha256-unit.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256 ()

--- a/tests/rt/pos/core/sha256L-string01.golden
+++ b/tests/rt/pos/core/sha256L-string01.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:12.715Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "Ri84oDxQLjDfe06VVJP/+0RKm/8WP+oKXMomclm0BL0="@{}%{}

--- a/tests/rt/pos/core/sha256L-string01.trp
+++ b/tests/rt/pos/core/sha256L-string01.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256L "Hello, Troupe!"

--- a/tests/rt/pos/core/sha256L-string02.golden
+++ b/tests/rt/pos/core/sha256L-string02.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:12.775Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "OLK9ikguRhubhYQfwy/Db9X1Oe/la93LU8IxhKyNGFE="@{alice}%{}

--- a/tests/rt/pos/core/sha256L-string02.trp
+++ b/tests/rt/pos/core/sha256L-string02.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256L ("Hello, Secret!" raisedTo `{alice}`)

--- a/tests/rt/pos/core/sha256L-string03.golden
+++ b/tests/rt/pos/core/sha256L-string03.golden
@@ -1,0 +1,2 @@
+2025-12-04T13:34:13.651Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+>>> Main thread finished with value: "cf2CtuyVnJjwUpAhoJaVhFa4UU/jJTicaRPXa0Jua8E="@{bob}%{}

--- a/tests/rt/pos/core/sha256L-string03.trp
+++ b/tests/rt/pos/core/sha256L-string03.trp
@@ -1,0 +1,2 @@
+(* NOTE: Failure in this test does NOT necessarily mean there is an error. *)
+sha256L ("Hello, Secret!" raisedTo `{bob}`)


### PR DESCRIPTION
Adds the `sha256` and `sha256L` builtin to the Troupe runtime.

-  For the addition of nomadic values, we need to be able to hash these values. For me to be able to test it, I would like to have it as a builtin to see it work.
    
- A Troupe programmer probably also wants access to a cryptographic hash function of their values (unlike the algorithmic hash in the `Hash` module).

Left as a *draft* as this does not (yet) cover aggregate types and closures.