### PR TITLE
refactor: replace non-wrapping logic in `HashSet` with something easier to maintain

### DIFF
--- a/lib/HashMap.trp
+++ b/lib/HashMap.trp
@@ -39,7 +39,6 @@ let (* NOTE: The map is implemented as a Hash Array Mapped Trie (HAMT), i.e. a p
 
     (** Filter a leaf to all entries that match the given key. That is, returns `[value]` for
      *  `value` associated with key `k` and `[]` otherwise. *)
-    (* TODO (Optimisation): early termination if found. *)
     fun leaf_findOpt n k = ListPair.findOpt n k
 
     (* TODO (Optimisation): combined find/map instead of filter? *)

--- a/lib/HashSet.trp
+++ b/lib/HashSet.trp
@@ -40,10 +40,7 @@ let (* NOTE: The set is implemented as a HashMap with dummy values, `()`. This i
 
     (** Returns the set (using the provided hash function) that contains all elements in the given
         list. Tail-recursive. *)
-    (* TODO: Prettier code would be `HashMap.fromList (List.map (fn x => (x, dummy)))`; if
-     *       `HashMap.fromList` suddenly gets optimised, then we can piggyback on that. Yet, this
-     *       would result in O(n) extra time and space usage. *)
-    fun fromList hf xs = List.foldl (fn (x, s) => insert s x) (empty hf) xs
+    fun fromList hf xs = HashMap.fromList hf (List.map (fn x => (x, dummy)) xs)
 
 in [ ("empty", empty)
    , ("singleton", singleton)


### PR DESCRIPTION
As I'm looking at the `HashMap` and `HashSet` anew to implement a P2P cache, I noticed my attempt to safe O(n) space. Yet, as also noted in the commit that does not seem worth the additional maintenance requirement.