### PR TITLE
Dev multinode cicd timeout tweaks

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -55,12 +55,14 @@ done
 
 if [ $? -eq 0 ]; then
     eval "node --stack-trace-limit=1000 \"$TROUPE/rt/built/troupe.mjs\" -f=\"$tmp\" --localonly $runtime_args"
+    exit_code=$?
     if [ "$keep_temp" = false ]; then
         rm "$tmp"
     else
         echo "Temporary file kept at: $tmp"
     fi
-else 
+    exit $exit_code
+else
     exit $?
 fi    
 

--- a/rt/src/builtins/exit.mts
+++ b/rt/src/builtins/exit.mts
@@ -1,6 +1,7 @@
 import { UserRuntimeZero, Constructor, mkBase } from './UserRuntimeZero.mjs'
 import { assertNormalState, assertIsNTuple, assertIsAuthority, assertIsNumber, assertIsRootAuthority } from '../Asserts.mjs'
 import { __unit } from '../UnitVal.mjs';
+import { setExitInitiated } from '../runtimeMonitored.mjs';
 
 
 export function BuiltinExit <TBase extends Constructor<UserRuntimeZero>>(Base: TBase) {
@@ -12,6 +13,7 @@ export function BuiltinExit <TBase extends Constructor<UserRuntimeZero>>(Base: T
             assertIsAuthority(arg.val[0]);
             assertIsNumber(arg.val[1]);
             assertIsRootAuthority(arg.val[0]);
+            setExitInitiated();  // Prevent compiler exit handler from interfering
             (async () => {
                 await $r.cleanup()
                 process.exit(arg.val[1].val);

--- a/rt/src/deserialize.mts
+++ b/rt/src/deserialize.mts
@@ -2,6 +2,7 @@
 import { strict as assert } from 'node:assert'
 import {spawn} from 'child_process'
 import * as Ty from './TroupeTypes.mjs'
+import { __exitInitiated } from './runtimeMonitored.mjs';
 import { LVal } from './Lval.mjs';
 import { mkTuple, mkList } from './ValuesUtil.mjs';
 import { ProcessID } from './process.mjs';
@@ -41,7 +42,10 @@ const HEADER:string =
 function startCompiler() {
     __compilerOsProcess = spawn(process.env.TROUPE + '/bin/troupec', ['--json-ir']);
     __compilerOsProcess.on('exit', (code: number) => {
-        process.exit(code);
+        // Don't exit if runtime's exit() was already called - it will handle the exit code
+        if (!__exitInitiated) {
+            process.exit(code);
+        }
     });
 
     let marker = "/*-----*/\n\n"

--- a/rt/src/runtimeMonitored.mts
+++ b/rt/src/runtimeMonitored.mts
@@ -48,6 +48,12 @@ const error = x => logger.error(x)
 
 let __p2pRunning = false;
 
+// Flag to prevent compiler exit handler from interfering with intended exit code
+export let __exitInitiated = false;
+export function setExitInitiated() {
+    __exitInitiated = true;
+}
+
 
 let rt_xconsole = 
       new Console({ stdout: process.stdout

--- a/scripts/run-multinode-tests.sh
+++ b/scripts/run-multinode-tests.sh
@@ -51,7 +51,7 @@ run_test() {
     local start_time
     start_time=$(date +%s)
     
-    if "$SCRIPT_DIR/multinode-runner.sh" ${VERBOSE:+-v} "$test_config" 2>&1 | tee "$TEMP_DIR/${test_name}.log"; then
+    if "$TROUPE_ROOT/scripts/multinode-runner.sh" ${VERBOSE:+-v} "$test_config" 2>&1 | tee "$TEMP_DIR/${test_name}.log"; then
         local end_time
         end_time=$(date +%s)
         local duration=$((end_time - start_time))

--- a/tests/rt/multinode-tests/README.md
+++ b/tests/rt/multinode-tests/README.md
@@ -109,7 +109,7 @@ Tests validate:
 (* Test Template *)
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 25 
+        let val _ = sleep 25000
         in exit(authority, 124) (* Timeout *)
         end)
     

--- a/tests/rt/multinode-tests/basic-echo/echo-client.trp
+++ b/tests/rt/multinode-tests/basic-echo/echo-client.trp
@@ -9,7 +9,7 @@ let
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting echo client"
-            val _ = sleep 2  (* Give server time to register *)
+            val _ = sleep 2000  (* Give server time to register *)
             
             val echo_server = whereis("@server", "echo")
             val _ = print "CLIENT: Found echo server"

--- a/tests/rt/multinode-tests/basic-echo/echo-client.trp
+++ b/tests/rt/multinode-tests/basic-echo/echo-client.trp
@@ -3,13 +3,13 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 20000 (* 20 second timeout *)
+        let val _ = sleep 8000 (* 8 second timeout *)
         in exit(authority, 124) (* Timeout exit code *)
         end)
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting echo client"
-            val _ = sleep 2000  (* Give server time to register *)
+            val _ = sleep 200  (* Give server time to register *)
             
             val echo_server = whereis("@server", "echo")
             val _ = print "CLIENT: Found echo server"

--- a/tests/rt/multinode-tests/basic-echo/echo-server.trp
+++ b/tests/rt/multinode-tests/basic-echo/echo-server.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 25000 (* 25 second timeout *)
+        let val _ = sleep 8000 (* 8 second timeout *)
         in exit(authority, 124) (* Timeout exit code *)
         end)
     
@@ -18,7 +18,7 @@ let
                     let val _ = print ("SERVER: Received echo request: " ^ msg)
                         val _ = send(sender, ("REPLY", msg))
                         val _ = print ("SERVER: Sent reply: " ^ msg)
-                        val _ = sleep 1000
+                        val _ = sleep 500
                     in "success"
                     end
             ]

--- a/tests/rt/multinode-tests/cross-spawn/spawner.trp
+++ b/tests/rt/multinode-tests/cross-spawn/spawner.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 25000 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/cross-spawn/target.trp
+++ b/tests/rt/multinode-tests/cross-spawn/target.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -14,7 +14,7 @@ let
             (* The target node doesn't need to do anything special *)
             (* Remote spawning will automatically create processes here *)
             (* We just wait for the test to complete *)
-            val _ = sleep 5000  (* Wait for spawned process to complete *)
+            val _ = sleep 2000  (* Wait for spawned process to complete *)
             
         in (print "TARGET: Test completed";
             exit(authority, 0))

--- a/tests/rt/multinode-tests/multi-client/client1.trp
+++ b/tests/rt/multinode-tests/multi-client/client1.trp
@@ -2,13 +2,13 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 25000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
     fun client1() = 
         let val _ = print "CLIENT1: Starting"
-            val _ = sleep 2000  (* Give server time to register *)
+            val _ = sleep 500  (* Give server time to register *)
             
             val echo_server = whereis("@server", "echo")
             val _ = print "CLIENT1: Found echo server"

--- a/tests/rt/multinode-tests/multi-client/client2.trp
+++ b/tests/rt/multinode-tests/multi-client/client2.trp
@@ -2,13 +2,13 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 25000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
     fun client2() = 
         let val _ = print "CLIENT2: Starting"
-            val _ = sleep 3000  (* Slightly different delay *)
+            val _ = sleep 1000  (* Slightly different delay *)
             
             val echo_server = whereis("@server", "echo")
             val _ = print "CLIENT2: Found echo server"

--- a/tests/rt/multinode-tests/multi-client/echo-server.trp
+++ b/tests/rt/multinode-tests/multi-client/echo-server.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000 (* 30 second timeout *)
+        let val _ = sleep 10000 (* 10 second timeout *)
         in exit(authority, 124)
         end)
     
@@ -16,7 +16,7 @@ let
             fun handle_messages n =
                 if n <= 0 then
                     (print "SERVER: Handled all client messages successfully";
-                     sleep 1000; (* enough time to flush all the messages *)
+                     sleep 500; (* enough time to flush all the messages *)
                      exit(authority, 0))
                 else
                     let val result = receive [

--- a/tests/rt/multinode-tests/ring-echo-3/echo-client.trp
+++ b/tests/rt/multinode-tests/ring-echo-3/echo-client.trp
@@ -1,12 +1,12 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting ring echo test with 3 intermediaries"
-            val _ = sleep 3000
+            val _ = sleep 1000
             
             val intermediary1 = whereis("@intermediary1", "proxy")
             val _ = print "CLIENT: Found intermediary1 proxy"

--- a/tests/rt/multinode-tests/ring-echo-3/echo-server.trp
+++ b/tests/rt/multinode-tests/ring-echo-3/echo-server.trp
@@ -1,6 +1,6 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -14,7 +14,7 @@ let
                     let val _ = print ("SERVER: Received echo request: " ^ msg)
                         val _ = print "SERVER: Replying directly to client"
                         val _ = send(client_pid, ("ECHO_REPLY", "Echo: " ^ msg, self()))
-                        val _ = sleep 1000
+                        val _ = sleep 500
                     in "success"
                     end
             ]

--- a/tests/rt/multinode-tests/ring-echo-3/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-3/intermediary1.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-3/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-3/intermediary2.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-3/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-3/intermediary3.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
@@ -1,12 +1,12 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 75000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting ring echo test with 5 intermediaries"
-            val _ = sleep 8000
+            val _ = sleep 1500
             
             val intermediary1 = whereis("@intermediary1", "proxy")
             val _ = print "CLIENT: Found intermediary1 proxy"

--- a/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
@@ -6,7 +6,7 @@ let
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting ring echo test with 5 intermediaries"
-            val _ = sleep 4000
+            val _ = sleep 8000
             
             val intermediary1 = whereis("@intermediary1", "proxy")
             val _ = print "CLIENT: Found intermediary1 proxy"

--- a/tests/rt/multinode-tests/ring-echo-5/echo-server.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/echo-server.trp
@@ -1,6 +1,6 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -14,7 +14,7 @@ let
                     let val _ = print ("SERVER: Received echo request: " ^ msg)
                         val _ = print "SERVER: Replying directly to client"
                         val _ = send(client_pid, ("ECHO_REPLY", "Echo: " ^ msg, self()))
-                        val _ = sleep 1000
+                        val _ = sleep 500
                     in "success"
                     end
             ]

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
@@ -1,8 +1,6 @@
 let
-    val timeout_pid = spawn(fn () =>
-        let val _ = print "INTERMEDIARY1: Timeout thread started"
-            val _ = sleep 10000
-            val _ = print "INTERMEDIARY1: Timeout firing, exiting with 124"
+    val timeout_pid = spawn(fn () => 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -10,24 +8,19 @@ let
         let val _ = print "INTERMEDIARY1: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY1: Registered proxy service"
-
+            
             fun proxy_loop() =
-                let val _ = print "INTERMEDIARY1: Entering receive"
-                    val result = receive [
-                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                            let val _ = print ("INTERMEDIARY1: Forwarding message to " ^ next_node)
-                                val next_proxy = whereis(next_node, "proxy")
-                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary3"))
-                                val _ = print "INTERMEDIARY1: Message forwarded"
-                            in "continue"
-                            end
-                    ]
-                    val _ = print ("INTERMEDIARY1: Receive returned: " ^ result)
-                in proxy_loop()
-                end
+                receive [
+                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                        let val _ = print ("INTERMEDIARY1: Forwarding message to " ^ next_node)
+                            val next_proxy = whereis(next_node, "proxy")
+                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary3"))
+                            val _ = print "INTERMEDIARY1: Message forwarded"
+                        in proxy_loop()
+                        end
+                ]
         in proxy_loop()
         end
 
-in proxy_server();
-   print "INTERMEDIARY1: proxy_server returned unexpectedly!"
+in proxy_server()
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
@@ -10,19 +10,24 @@ let
         let val _ = print "INTERMEDIARY1: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY1: Registered proxy service"
-            
+
             fun proxy_loop() =
-                receive [
-                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                        let val _ = print ("INTERMEDIARY1: Forwarding message to " ^ next_node)
-                            val next_proxy = whereis(next_node, "proxy")
-                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary3"))
-                            val _ = print "INTERMEDIARY1: Message forwarded"
-                        in proxy_loop()
-                        end
-                ]
+                let val _ = print "INTERMEDIARY1: Entering receive"
+                    val result = receive [
+                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                            let val _ = print ("INTERMEDIARY1: Forwarding message to " ^ next_node)
+                                val next_proxy = whereis(next_node, "proxy")
+                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary3"))
+                                val _ = print "INTERMEDIARY1: Message forwarded"
+                            in "continue"
+                            end
+                    ]
+                    val _ = print ("INTERMEDIARY1: Receive returned: " ^ result)
+                in proxy_loop()
+                end
         in proxy_loop()
         end
 
-in proxy_server()
+in proxy_server();
+   print "INTERMEDIARY1: proxy_server returned unexpectedly!"
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
@@ -1,6 +1,8 @@
 let
-    val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+    val timeout_pid = spawn(fn () =>
+        let val _ = print "INTERMEDIARY1: Timeout thread started"
+            val _ = sleep 30000
+            val _ = print "INTERMEDIARY1: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
@@ -1,7 +1,7 @@
 let
     val timeout_pid = spawn(fn () =>
         let val _ = print "INTERMEDIARY1: Timeout thread started"
-            val _ = sleep 30000
+            val _ = sleep 10000
             val _ = print "INTERMEDIARY1: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
@@ -1,6 +1,8 @@
 let
-    val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+    val timeout_pid = spawn(fn () =>
+        let val _ = print "INTERMEDIARY2: Timeout thread started"
+            val _ = sleep 30000
+            val _ = print "INTERMEDIARY2: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
@@ -1,8 +1,6 @@
 let
-    val timeout_pid = spawn(fn () =>
-        let val _ = print "INTERMEDIARY2: Timeout thread started"
-            val _ = sleep 10000
-            val _ = print "INTERMEDIARY2: Timeout firing, exiting with 124"
+    val timeout_pid = spawn(fn () => 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -10,24 +8,19 @@ let
         let val _ = print "INTERMEDIARY2: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY2: Registered proxy service"
-
+            
             fun proxy_loop() =
-                let val _ = print "INTERMEDIARY2: Entering receive"
-                    val result = receive [
-                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                            let val _ = print ("INTERMEDIARY2: Forwarding message to " ^ next_node)
-                                val next_proxy = whereis(next_node, "proxy")
-                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary4"))
-                                val _ = print "INTERMEDIARY2: Message forwarded"
-                            in "continue"
-                            end
-                    ]
-                    val _ = print ("INTERMEDIARY2: Receive returned: " ^ result)
-                in proxy_loop()
-                end
+                receive [
+                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                        let val _ = print ("INTERMEDIARY2: Forwarding message to " ^ next_node)
+                            val next_proxy = whereis(next_node, "proxy")
+                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary4"))
+                            val _ = print "INTERMEDIARY2: Message forwarded"
+                        in proxy_loop()
+                        end
+                ]
         in proxy_loop()
         end
 
-in proxy_server();
-   print "INTERMEDIARY2: proxy_server returned unexpectedly!"
+in proxy_server()
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
@@ -1,7 +1,7 @@
 let
     val timeout_pid = spawn(fn () =>
         let val _ = print "INTERMEDIARY2: Timeout thread started"
-            val _ = sleep 30000
+            val _ = sleep 10000
             val _ = print "INTERMEDIARY2: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
@@ -10,19 +10,24 @@ let
         let val _ = print "INTERMEDIARY2: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY2: Registered proxy service"
-            
+
             fun proxy_loop() =
-                receive [
-                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                        let val _ = print ("INTERMEDIARY2: Forwarding message to " ^ next_node)
-                            val next_proxy = whereis(next_node, "proxy")
-                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary4"))
-                            val _ = print "INTERMEDIARY2: Message forwarded"
-                        in proxy_loop()
-                        end
-                ]
+                let val _ = print "INTERMEDIARY2: Entering receive"
+                    val result = receive [
+                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                            let val _ = print ("INTERMEDIARY2: Forwarding message to " ^ next_node)
+                                val next_proxy = whereis(next_node, "proxy")
+                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary4"))
+                                val _ = print "INTERMEDIARY2: Message forwarded"
+                            in "continue"
+                            end
+                    ]
+                    val _ = print ("INTERMEDIARY2: Receive returned: " ^ result)
+                in proxy_loop()
+                end
         in proxy_loop()
         end
 
-in proxy_server()
+in proxy_server();
+   print "INTERMEDIARY2: proxy_server returned unexpectedly!"
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
@@ -10,19 +10,24 @@ let
         let val _ = print "INTERMEDIARY3: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY3: Registered proxy service"
-            
+
             fun proxy_loop() =
-                receive [
-                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                        let val _ = print ("INTERMEDIARY3: Forwarding message to " ^ next_node)
-                            val next_proxy = whereis(next_node, "proxy")
-                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary5"))
-                            val _ = print "INTERMEDIARY3: Message forwarded"
-                        in proxy_loop()
-                        end
-                ]
+                let val _ = print "INTERMEDIARY3: Entering receive"
+                    val result = receive [
+                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                            let val _ = print ("INTERMEDIARY3: Forwarding message to " ^ next_node)
+                                val next_proxy = whereis(next_node, "proxy")
+                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary5"))
+                                val _ = print "INTERMEDIARY3: Message forwarded"
+                            in "continue"
+                            end
+                    ]
+                    val _ = print ("INTERMEDIARY3: Receive returned: " ^ result)
+                in proxy_loop()
+                end
         in proxy_loop()
         end
 
-in proxy_server()
+in proxy_server();
+   print "INTERMEDIARY3: proxy_server returned unexpectedly!"
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
@@ -1,7 +1,7 @@
 let
     val timeout_pid = spawn(fn () =>
         let val _ = print "INTERMEDIARY3: Timeout thread started"
-            val _ = sleep 30000
+            val _ = sleep 10000
             val _ = print "INTERMEDIARY3: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
@@ -1,6 +1,8 @@
 let
-    val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+    val timeout_pid = spawn(fn () =>
+        let val _ = print "INTERMEDIARY3: Timeout thread started"
+            val _ = sleep 30000
+            val _ = print "INTERMEDIARY3: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
@@ -1,8 +1,6 @@
 let
-    val timeout_pid = spawn(fn () =>
-        let val _ = print "INTERMEDIARY3: Timeout thread started"
-            val _ = sleep 10000
-            val _ = print "INTERMEDIARY3: Timeout firing, exiting with 124"
+    val timeout_pid = spawn(fn () => 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -10,24 +8,19 @@ let
         let val _ = print "INTERMEDIARY3: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY3: Registered proxy service"
-
+            
             fun proxy_loop() =
-                let val _ = print "INTERMEDIARY3: Entering receive"
-                    val result = receive [
-                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                            let val _ = print ("INTERMEDIARY3: Forwarding message to " ^ next_node)
-                                val next_proxy = whereis(next_node, "proxy")
-                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary5"))
-                                val _ = print "INTERMEDIARY3: Message forwarded"
-                            in "continue"
-                            end
-                    ]
-                    val _ = print ("INTERMEDIARY3: Receive returned: " ^ result)
-                in proxy_loop()
-                end
+                receive [
+                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                        let val _ = print ("INTERMEDIARY3: Forwarding message to " ^ next_node)
+                            val next_proxy = whereis(next_node, "proxy")
+                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@intermediary5"))
+                            val _ = print "INTERMEDIARY3: Message forwarded"
+                        in proxy_loop()
+                        end
+                ]
         in proxy_loop()
         end
 
-in proxy_server();
-   print "INTERMEDIARY3: proxy_server returned unexpectedly!"
+in proxy_server()
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
@@ -1,8 +1,6 @@
 let
-    val timeout_pid = spawn(fn () =>
-        let val _ = print "INTERMEDIARY4: Timeout thread started"
-            val _ = sleep 10000
-            val _ = print "INTERMEDIARY4: Timeout firing, exiting with 124"
+    val timeout_pid = spawn(fn () => 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -10,24 +8,19 @@ let
         let val _ = print "INTERMEDIARY4: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY4: Registered proxy service"
-
+            
             fun proxy_loop() =
-                let val _ = print "INTERMEDIARY4: Entering receive"
-                    val result = receive [
-                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                            let val _ = print ("INTERMEDIARY4: Forwarding message to " ^ next_node)
-                                val next_proxy = whereis(next_node, "proxy")
-                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@server"))
-                                val _ = print "INTERMEDIARY4: Message forwarded"
-                            in "continue"
-                            end
-                    ]
-                    val _ = print ("INTERMEDIARY4: Receive returned: " ^ result)
-                in proxy_loop()
-                end
+                receive [
+                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                        let val _ = print ("INTERMEDIARY4: Forwarding message to " ^ next_node)
+                            val next_proxy = whereis(next_node, "proxy")
+                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@server"))
+                            val _ = print "INTERMEDIARY4: Message forwarded"
+                        in proxy_loop()
+                        end
+                ]
         in proxy_loop()
         end
 
-in proxy_server();
-   print "INTERMEDIARY4: proxy_server returned unexpectedly!"
+in proxy_server()
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
@@ -10,19 +10,24 @@ let
         let val _ = print "INTERMEDIARY4: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY4: Registered proxy service"
-            
+
             fun proxy_loop() =
-                receive [
-                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                        let val _ = print ("INTERMEDIARY4: Forwarding message to " ^ next_node)
-                            val next_proxy = whereis(next_node, "proxy")
-                            val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@server"))
-                            val _ = print "INTERMEDIARY4: Message forwarded"
-                        in proxy_loop()
-                        end
-                ]
+                let val _ = print "INTERMEDIARY4: Entering receive"
+                    val result = receive [
+                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                            let val _ = print ("INTERMEDIARY4: Forwarding message to " ^ next_node)
+                                val next_proxy = whereis(next_node, "proxy")
+                                val _ = send(next_proxy, ("FORWARD_ECHO", msg, client_pid, "@server"))
+                                val _ = print "INTERMEDIARY4: Message forwarded"
+                            in "continue"
+                            end
+                    ]
+                    val _ = print ("INTERMEDIARY4: Receive returned: " ^ result)
+                in proxy_loop()
+                end
         in proxy_loop()
         end
 
-in proxy_server()
+in proxy_server();
+   print "INTERMEDIARY4: proxy_server returned unexpectedly!"
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
@@ -1,6 +1,8 @@
 let
-    val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+    val timeout_pid = spawn(fn () =>
+        let val _ = print "INTERMEDIARY4: Timeout thread started"
+            val _ = sleep 30000
+            val _ = print "INTERMEDIARY4: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
@@ -1,7 +1,7 @@
 let
     val timeout_pid = spawn(fn () =>
         let val _ = print "INTERMEDIARY4: Timeout thread started"
-            val _ = sleep 30000
+            val _ = sleep 10000
             val _ = print "INTERMEDIARY4: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
@@ -1,7 +1,7 @@
 let
     val timeout_pid = spawn(fn () =>
         let val _ = print "INTERMEDIARY5: Timeout thread started"
-            val _ = sleep 30000
+            val _ = sleep 10000
             val _ = print "INTERMEDIARY5: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
@@ -1,6 +1,8 @@
 let
-    val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+    val timeout_pid = spawn(fn () =>
+        let val _ = print "INTERMEDIARY5: Timeout thread started"
+            val _ = sleep 30000
+            val _ = print "INTERMEDIARY5: Timeout firing, exiting with 124"
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
@@ -10,19 +10,24 @@ let
         let val _ = print "INTERMEDIARY5: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY5: Registered proxy service"
-            
+
             fun proxy_loop() =
-                receive [
-                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                        let val _ = print ("INTERMEDIARY5: Forwarding message to " ^ next_node)
-                            val echo_service = whereis(next_node, "echo")
-                            val _ = send(echo_service, ("ECHO", msg, client_pid))
-                            val _ = print "INTERMEDIARY5: Message forwarded to server"
-                        in proxy_loop()
-                        end
-                ]
+                let val _ = print "INTERMEDIARY5: Entering receive"
+                    val result = receive [
+                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                            let val _ = print ("INTERMEDIARY5: Forwarding message to " ^ next_node)
+                                val echo_service = whereis(next_node, "echo")
+                                val _ = send(echo_service, ("ECHO", msg, client_pid))
+                                val _ = print "INTERMEDIARY5: Message forwarded to server"
+                            in "continue"
+                            end
+                    ]
+                    val _ = print ("INTERMEDIARY5: Receive returned: " ^ result)
+                in proxy_loop()
+                end
         in proxy_loop()
         end
 
-in proxy_server()
+in proxy_server();
+   print "INTERMEDIARY5: proxy_server returned unexpectedly!"
 end

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
@@ -1,8 +1,6 @@
 let
-    val timeout_pid = spawn(fn () =>
-        let val _ = print "INTERMEDIARY5: Timeout thread started"
-            val _ = sleep 10000
-            val _ = print "INTERMEDIARY5: Timeout firing, exiting with 124"
+    val timeout_pid = spawn(fn () => 
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -10,24 +8,19 @@ let
         let val _ = print "INTERMEDIARY5: Starting proxy service"
             val _ = register("proxy", self(), authority)
             val _ = print "INTERMEDIARY5: Registered proxy service"
-
+            
             fun proxy_loop() =
-                let val _ = print "INTERMEDIARY5: Entering receive"
-                    val result = receive [
-                        hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
-                            let val _ = print ("INTERMEDIARY5: Forwarding message to " ^ next_node)
-                                val echo_service = whereis(next_node, "echo")
-                                val _ = send(echo_service, ("ECHO", msg, client_pid))
-                                val _ = print "INTERMEDIARY5: Message forwarded to server"
-                            in "continue"
-                            end
-                    ]
-                    val _ = print ("INTERMEDIARY5: Receive returned: " ^ result)
-                in proxy_loop()
-                end
+                receive [
+                    hn ("FORWARD_ECHO", msg, client_pid, next_node) =>
+                        let val _ = print ("INTERMEDIARY5: Forwarding message to " ^ next_node)
+                            val echo_service = whereis(next_node, "echo")
+                            val _ = send(echo_service, ("ECHO", msg, client_pid))
+                            val _ = print "INTERMEDIARY5: Message forwarded to server"
+                        in proxy_loop()
+                        end
+                ]
         in proxy_loop()
         end
 
-in proxy_server();
-   print "INTERMEDIARY5: proxy_server returned unexpectedly!"
+in proxy_server()
 end

--- a/tests/rt/multinode-tests/ring-echo/echo-client.trp
+++ b/tests/rt/multinode-tests/ring-echo/echo-client.trp
@@ -1,12 +1,12 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
     fun echo_client() = 
         let val _ = print "CLIENT: Starting ring echo test"
-            val _ = sleep 2000
+            val _ = sleep 500
             
             val intermediary = whereis("@intermediary", "proxy")
             val _ = print "CLIENT: Found intermediary proxy"

--- a/tests/rt/multinode-tests/ring-echo/echo-server.trp
+++ b/tests/rt/multinode-tests/ring-echo/echo-server.trp
@@ -1,6 +1,6 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     
@@ -14,7 +14,7 @@ let
                     let val _ = print ("SERVER: Received echo request: " ^ msg)
                         val _ = print "SERVER: Replying directly to client"
                         val _ = send(client_pid, ("ECHO_REPLY", "Echo: " ^ msg, self()))
-                        val _ = sleep 1000
+                        val _ = sleep 500
                     in "success"
                     end
             ]

--- a/tests/rt/multinode-tests/ring-echo/intermediary.trp
+++ b/tests/rt/multinode-tests/ring-echo/intermediary.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 30000
+        let val _ = sleep 10000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/trust-flow-issue-42/node1.trp
+++ b/tests/rt/multinode-tests/trust-flow-issue-42/node1.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 8000
+        let val _ = sleep 5000
         in print "NODE1: Timeout reached - main thread likely encountered expected error"; exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/trust-flow-issue-42/node1.trp
+++ b/tests/rt/multinode-tests/trust-flow-issue-42/node1.trp
@@ -3,7 +3,7 @@
 
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10 
+        let val _ = sleep 8000
         in print "NODE1: Timeout reached - main thread likely encountered expected error"; exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/trust-flow-issue-42/node2.trp
+++ b/tests/rt/multinode-tests/trust-flow-issue-42/node2.trp
@@ -3,7 +3,7 @@
 
 let val _ = print "NODE2: Started and waiting"
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 7000
+        let val _ = sleep 4000
         in print "NODE2: Timeout - no spawn received (expected)"; exit(authority, 0)
         end)
 in

--- a/tests/rt/multinode-tests/trust-flow-issue-42/node2.trp
+++ b/tests/rt/multinode-tests/trust-flow-issue-42/node2.trp
@@ -3,7 +3,7 @@
 
 let val _ = print "NODE2: Started and waiting"
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 8
+        let val _ = sleep 7000
         in print "NODE2: Timeout - no spawn received (expected)"; exit(authority, 0)
         end)
 in


### PR DESCRIPTION
This PR brings in the bug fix https://github.com/TroupeLang/Troupe/commit/b2831125fb9d5d6a62ce877b147a3d2cb0a17f24 that addresses a race condition that might have been causing failures in multimode tests. Subsequent commits tweak the timeout constants to minimize time spent in multinode testing.