### PR TITLE
chore: kick out `ceil` and `round` from the TCB

### DIFF
--- a/compiler/src/IR.hs
+++ b/compiler/src/IR.hs
@@ -314,7 +314,6 @@ instance WellFormedIRCheck IRExpr where
                      , "blockdownto"
                      , "blockendorse"
                      , "blockendorseto"
-                     , "ceil"
                      , "cert"
                      , "charCodeAtWithDefault"
                      , "coalesce"

--- a/compiler/src/IR.hs
+++ b/compiler/src/IR.hs
@@ -363,7 +363,6 @@ instance WellFormedIRCheck IRExpr where
                      , "_resetScheduler"
                      , "rcv"
                      , "rcvp"
-                     , "round"
                      , "sandbox"
                      , "save"
                      , "send"

--- a/lib/Number.trp
+++ b/lib/Number.trp
@@ -60,10 +60,12 @@ let (*--- Constants ---*)
     fun ceil x = -(floor (-x))
 
     (** Returns the integer, `x'`, with the least distance to `x` (ties are broken by the largest).
-     *
-     * TODO: Move out of the TCB?
      *)
-    val round = round
+    fun round x =
+        let val fx  = floor x
+            val fx' = floor (x + 0.5)
+        in if fx = fx' then fx else fx'
+        end
 
     (** Returns the square root of *x*, i.e. the number, `x'` such that `x' * x' = x`.
      *

--- a/lib/Number.trp
+++ b/lib/Number.trp
@@ -62,9 +62,9 @@ let (*--- Constants ---*)
     (** Returns the integer, `x'`, with the least distance to `x` (ties are broken by the largest).
      *)
     fun round x =
-        let val fx  = floor x
-            val fx' = floor (x + 0.5)
-        in if fx = fx' then fx else fx'
+        let val fx = floor x
+            val d  = x - fx
+        in floor (fx + 2*d)
         end
 
     (** Returns the square root of *x*, i.e. the number, `x'` such that `x' * x' = x`.

--- a/lib/Number.trp
+++ b/lib/Number.trp
@@ -47,19 +47,19 @@ let (*--- Constants ---*)
     (** Returns the largest value in the tuple. *)
     fun max (x,y) = if x < y then y else x
 
-    (** Returns the *ceiling* of the given number, `x`, i.e. the smallest integral number larger
-     *  than `x`.
-     *
-     * TODO: Move out of the TCB?
-     *)
-    val ceil = ceil
-
     (** Returns the *floor* of the given number, `x`, i.e. the largest integral number smaller than
      *  `x`.
      *
      * TODO: Move out of the TCB?
      *)
     val floor = floor
+
+    (** Returns the *ceiling* of the given number, `x`, i.e. the smallest integral number larger
+     *  than `x`.
+     *
+     * TODO: Move out of the TCB?
+     *)
+    val ceil = ceil
 
     (** Returns the integer, `x'`, with the least distance to `x` (ties are broken by the largest).
      *

--- a/lib/Number.trp
+++ b/lib/Number.trp
@@ -56,10 +56,8 @@ let (*--- Constants ---*)
 
     (** Returns the *ceiling* of the given number, `x`, i.e. the smallest integral number larger
      *  than `x`.
-     *
-     * TODO: Move out of the TCB?
      *)
-    val ceil = ceil
+    fun ceil x = -(floor (-x))
 
     (** Returns the integer, `x'`, with the least distance to `x` (ties are broken by the largest).
      *

--- a/rt/src/builtins/math.mts
+++ b/rt/src/builtins/math.mts
@@ -12,11 +12,6 @@ export function BuiltinMath <TBase extends Constructor<UserRuntimeZero>> (Base:T
             return this.runtime.ret(new LVal(Math.random(), levels.BOT, levels.BOT))
         })
 
-        round = mkBase((arg) => {
-            assertIsNumber(arg);
-            return this.runtime.ret(new LVal(Math.round(arg.val), arg.lev, arg.tlev));
-        })
-
         floor = mkBase((arg) => {
             assertIsNumber(arg);
             return this.runtime.ret(new LVal(Math.floor(arg.val), arg.lev, arg.tlev));

--- a/rt/src/builtins/math.mts
+++ b/rt/src/builtins/math.mts
@@ -12,11 +12,6 @@ export function BuiltinMath <TBase extends Constructor<UserRuntimeZero>> (Base:T
             return this.runtime.ret(new LVal(Math.random(), levels.BOT, levels.BOT))
         })
 
-        ceil = mkBase((arg) => {
-            assertIsNumber(arg);
-            return this.runtime.ret(new LVal(Math.ceil(arg.val), arg.lev, arg.tlev));
-        })
-
         round = mkBase((arg) => {
             assertIsNumber(arg);
             return this.runtime.ret(new LVal(Math.round(arg.val), arg.lev, arg.tlev));

--- a/tests/rt/pos/core/float_ops.golden
+++ b/tests/rt/pos/core/float_ops.golden
@@ -1,5 +1,5 @@
-2020-03-03T22:59:26.210Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+2026-02-16T15:45:21.023Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
 (0.5, 0.75, 2, 1)
-(3, 2, 2)
-(2, 1, 2)
+2
+1
 >>> Main thread finished with value: ()@{}%{}

--- a/tests/rt/pos/core/float_ops.nocolor.golden
+++ b/tests/rt/pos/core/float_ops.nocolor.golden
@@ -1,5 +1,0 @@
-2025-06-24T21:28:21.805Z [RTM] info: Skipping network creation. Observe that all external IO operations will yield a runtime error.
-(0.5, 0.75, 2, 1)
-(3, 2, 2)
-(2, 1, 2)
->>> Main thread finished with value: ()@{}%{}

--- a/tests/rt/pos/core/float_ops.trp
+++ b/tests/rt/pos/core/float_ops.trp
@@ -1,7 +1,7 @@
 let val _ =  print (1/2 , 3 / 4, 5 div 2, 5 mod 2)
     val x = 32/15 
     val y = 32/17
-    val ops_x = (ceil x, floor x, round x)
-    val ops_y = (ceil y, floor y, round y)
+    val ops_x = floor x
+    val ops_y = floor y
 in print ops_x; print ops_y
 end


### PR DESCRIPTION
Removes `ceil` and `round` from the TCB since they can be easily be derived from `floor`. For now, I've left `floor` in but it should also be possible to do in Troupe only; this would either be some other builtins (maybe division and multiplication?) and/or a binary search.