### PR TITLE
refactor: `String.substring` and related signatures

### DIFF
--- a/lib/Hash.trp
+++ b/lib/Hash.trp
@@ -48,9 +48,10 @@ let
         let fun hashType x = case getType x of "number"   => 2
                                              | "string"   => 3
                                              | "list"     => 5
-                                             | "record"   => 7
-                                             | "function" => 11
-                                             | _          => 13
+                                             | "tuple"    => 7
+                                             | "record"   => 11
+                                             | "function" => 13
+                                             | _          => 17
             val p = 3
             fun go i []    acc = acc
               | go i x::xs acc =
@@ -62,6 +63,7 @@ let
     and hash x = case getType x of "number"   => hashNumber x
                                  | "string"   => hashString x
                                  | "list"     => hashList x
+                              (* | "tuple"    => TODO: Run recursively on tuples? *)
                               (* | "record"   => TODO: Convert to sorted list? *)
                               (* | "function" => TODO: How to hash the function body? *)
                                  | _          => hashString (toString x)

--- a/lib/Hash.trp
+++ b/lib/Hash.trp
@@ -10,9 +10,9 @@ let
      *)
     fun hashString s =
         (* String hash with fast paths for small strings *)
-        let val len     = String.size s
-            val radix   = 127
-            val subCode = String.subCode s
+        let val len       = String.size s
+            val radix     = 127
+            fun subCode i = String.subCode (s, i)
         in case len of 0 => 0
                      | 1 => subCode 0
                      | 2 => (radix * subCode 0 + subCode 1) andb Number.maxInt32

--- a/lib/Html.trp
+++ b/lib/Html.trp
@@ -25,13 +25,13 @@ let (* --- Helper Functions --- *)
 
     (* Convert a character to lowercase (ASCII only) *)
     fun toLowerChar c =
-        let val code = String.subCode c 0
+        let val code = String.subCode (c, 0)
         in if code >= 65 andalso code <= 90  (* A-Z *)
            then let (* Build lowercase char from code: a=97, A=65, so add 32 *)
                     val lowerCode = code + 32
                     (* Use simple mapping for common cases *)
                     val chars = "abcdefghijklmnopqrstuvwxyz"
-                in String.sub chars (code - 65) end
+                in String.sub (chars, code - 65) end
            else c
         end
 
@@ -76,7 +76,7 @@ let (* --- Helper Functions --- *)
     fun escapeAttr s =
         let fun escapeChar c =
                 let val base = escapeBase c
-                in if base = c andalso String.subCode c 0 = 39  (* single quote *)
+                in if base = c andalso String.subCode (c, 0) = 39  (* single quote *)
                    then "&#39;"
                    else base
                 end

--- a/lib/README.md
+++ b/lib/README.md
@@ -38,8 +38,3 @@ target of the *makefile*.
 
 - The `ThreadUtil` module was initially named `Thread`. But, this suggests incorrectly, that
   threading is implemented here rather than being a language primitive.
-
-## TODO
-
-The [modules](#modules) mentioned above already follow the [design principles](#design-principles).
-The remaining files either need to be updated or to be removed.

--- a/lib/README.md
+++ b/lib/README.md
@@ -27,9 +27,7 @@ target of the *makefile*.
 ## Design Principles
 
 - File names are written in `CamelCase`. This makes them conform to the Standard ML Basis Library.
-- While we will try to match function names in the Standard ML library, we may take the liberty to
-  improve on the function signatures. For example, the function `String.sub` uses the same name as
-  in SML but uses the signature `[Char] -> Int -> Char` rather than `[Char] * Int -> Char`.
+- We will try to match function names in the Standard ML library.
 - Each module exports a single *record* with the same name as the file. This (1) makes it closer to
   the SML module system and (2) allows for name resolution, e.g. `HashMap.findOpt` and
   `ListPair.findOpt` can be used in the same file.

--- a/lib/String.trp
+++ b/lib/String.trp
@@ -2,8 +2,7 @@ import Number
 import List
 
 
-let val __substring = substring
-
+let
     (** The maximum length of a string.
      *
      * ECMA-262: 6.1.4 The String Type
@@ -18,16 +17,17 @@ let val __substring = substring
     (** Returns the length of string `s`. *)
     fun size s = strlen s
 
+    (** Returns the substring of `s` from `i` (inclusive) to `j` (exclusive). Indices beyond the end
+     *  of string are silently truncated. *)
+    val substring = substring
+
     (** Returns the `i`th character of `s`, counting from zero. If `i` is out of bounds, then "" is
      *  returned. *)
-    fun sub s i = __substring (s, i, i+1)
+    fun sub s i = substring (s, i, i+1)
 
     (** The character value at the given index. If `i` is out of bounds, then 0 (NULL) is
      *  returned. *)
     fun subCode s i = charCodeAtWithDefault (s, i, 0)
-
-    (** Returns the substring of `s`. Indices beyond the end of string are silently truncated. *)
-    fun substring s i j = __substring (s, i, j)
 
     (** The concatenation of all strings in `xs`. *)
     fun concat xs = let fun f ("",x') = x'
@@ -94,9 +94,9 @@ let val __substring = substring
 
 in [ ("maxSize", maxSize)
    , ("size", size)
+   , ("substring", substring)
    , ("sub", sub)
    , ("subCode", subCode)
-   , ("substring", substring)
    , ("concat", concat)
    , ("concatWith", concatWith)
    , ("str", str)

--- a/lib/String.trp
+++ b/lib/String.trp
@@ -24,7 +24,6 @@ let val __substring = substring
 
     (** The character value at the given index. If `i` is out of bounds, then 0 (NULL) is
      *  returned. *)
-    (* TODO (#59): Rename to `sub'` when `'` symbols are properly supported. *)
     fun subCode s i = charCodeAtWithDefault (s, i, 0)
 
     (** Returns the substring of `s`. Indices beyond the end of string are silently truncated. *)
@@ -48,7 +47,7 @@ let val __substring = substring
      * if it a string of length 1. *)
     fun str c = c
 
-    (* TODO: `strCode`/`str'` where 'c' is a charCode that is converted. *)
+    (* TODO: `strCode` where 'c' is a charCode that is converted. *)
 
     (** Returns the string containing the characters in the list `xs`. This is equivalent to
      *  `concat (List.map str xs)`. *)
@@ -62,12 +61,12 @@ let val __substring = substring
     (** Applies `f` to each element of `f` from left to right, returning the resulting string. *)
     fun map f s = implode(List.map f (explode s))
 
-    (* TODO: `mapCode`/`map'` where one maps over charCodes instead. *)
+    (* TODO: `mapCode` where one maps over charCodes instead. *)
 
     (** Returns the string generated from `s` by mapping each character in `s` by `f`.  *)
     fun translate f s = concat(List.map f (explode s))
 
-    (* TODO: `translateCode`/`translate'` where one maps over charCodes instead. *)
+    (* TODO: `translateCode` where one maps over charCodes instead. *)
 
     (*--- Padding ---*)
 

--- a/lib/String.trp
+++ b/lib/String.trp
@@ -53,10 +53,14 @@ let val __substring = substring
      *  `concat (List.map str xs)`. *)
     val implode = concat
 
+    (* TODO: `implodeCode` to create a string from a list of charCodes (with or without NULL). *)
+
     (** Returns the list of characters in the string `s`. *)
     fun explode s = let fun go 0 acc = acc
                           | go i acc = go (i-1) ((sub s (i-1))::acc)
                     in go (size s) [] end
+
+    (* TODO: `explodeCode` where one obtaing the list of all charCodes (with NULL termination?). *)
 
     (** Applies `f` to each element of `f` from left to right, returning the resulting string. *)
     fun map f s = implode(List.map f (explode s))

--- a/lib/String.trp
+++ b/lib/String.trp
@@ -23,11 +23,11 @@ let
 
     (** Returns the `i`th character of `s`, counting from zero. If `i` is out of bounds, then "" is
      *  returned. *)
-    fun sub s i = substring (s, i, i+1)
+    fun sub (s, i) = substring (s, i, i+1)
 
     (** The character value at the given index. If `i` is out of bounds, then 0 (NULL) is
      *  returned. *)
-    fun subCode s i = charCodeAtWithDefault (s, i, 0)
+    fun subCode (s, i) = charCodeAtWithDefault (s, i, 0)
 
     (** The concatenation of all strings in `xs`. *)
     fun concat xs = let fun f ("",x') = x'
@@ -57,7 +57,7 @@ let
 
     (** Returns the list of characters in the string `s`. *)
     fun explode s = let fun go 0 acc = acc
-                          | go i acc = go (i-1) ((sub s (i-1))::acc)
+                          | go i acc = go (i-1) ((sub (s, i-1))::acc)
                     in go (size s) [] end
 
     (* TODO: `explodeCode` where one obtaing the list of all charCodes (with NULL termination?). *)

--- a/tests/lib/String.golden
+++ b/tests/lib/String.golden
@@ -1,4 +1,4 @@
-2025-09-10T10:39:43.344Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
+2026-02-16T15:39:18.731Z [RTM] [32minfo[39m: Skipping network creation. Observe that all external IO operations will yield a runtime error.
 [34mbegin [0mString
   [34mbegin [0msize
       [33m[ TEST ][0m it is 0 for ''      [32m[ PASS ][0m it is 0 for ''
@@ -6,6 +6,12 @@
       [33m[ TEST ][0m it is 1 for 'b'      [32m[ PASS ][0m it is 1 for 'b'
       [33m[ TEST ][0m it is 5 for 'Hello'      [32m[ PASS ][0m it is 5 for 'Hello'
       [33m[ TEST ][0m it is 7 for 'Troupe!'      [32m[ PASS ][0m it is 7 for 'Troupe!'
+  [34mend [0m
+  [34mbegin [0msubstring
+      [33m[ TEST ][0m it is 'Hello' for 0 5      [32m[ PASS ][0m it is 'Hello' for 0 5
+      [33m[ TEST ][0m it is 'Troupe' for 6 12      [32m[ PASS ][0m it is 'Troupe' for 6 12
+      [33m[ TEST ][0m it is 'Troupe!' for 6 13      [32m[ PASS ][0m it is 'Troupe!' for 6 13
+      [33m[ TEST ][0m it is 'Troupe!' for 6 14      [32m[ PASS ][0m it is 'Troupe!' for 6 14
   [34mend [0m
   [34mbegin [0msub
       [33m[ TEST ][0m it is 'H' for 0      [32m[ PASS ][0m it is 'H' for 0
@@ -24,12 +30,6 @@
       [33m[ TEST ][0m it is 100 for 4      [32m[ PASS ][0m it is 100 for 4
       [33m[ TEST ][0m it is 33  for 5      [32m[ PASS ][0m it is 33  for 5
       [33m[ TEST ][0m it is 0   for 6      [32m[ PASS ][0m it is 0   for 6
-  [34mend [0m
-  [34mbegin [0msubstring
-      [33m[ TEST ][0m it is 'Hello' for 0 5      [32m[ PASS ][0m it is 'Hello' for 0 5
-      [33m[ TEST ][0m it is 'Troupe' for 6 12      [32m[ PASS ][0m it is 'Troupe' for 6 12
-      [33m[ TEST ][0m it is 'Troupe!' for 6 13      [32m[ PASS ][0m it is 'Troupe!' for 6 13
-      [33m[ TEST ][0m it is 'Troupe!' for 6 14      [32m[ PASS ][0m it is 'Troupe!' for 6 14
   [34mend [0m
   [34mbegin [0mconcat
       [33m[ TEST ][0m it is '' for []      [32m[ PASS ][0m it is '' for []

--- a/tests/lib/String.nocolor.golden
+++ b/tests/lib/String.nocolor.golden
@@ -1,81 +1,0 @@
-2025-12-14T11:44:43.869Z [RTM] info: Skipping network creation. Observe that all external IO operations will yield a runtime error.
-[34mbegin [0mString
-  [34mbegin [0msize
-      [33m[ TEST ][0m it is 0 for ''      [32m[ PASS ][0m it is 0 for ''
-      [33m[ TEST ][0m it is 1 for 'a'      [32m[ PASS ][0m it is 1 for 'a'
-      [33m[ TEST ][0m it is 1 for 'b'      [32m[ PASS ][0m it is 1 for 'b'
-      [33m[ TEST ][0m it is 5 for 'Hello'      [32m[ PASS ][0m it is 5 for 'Hello'
-      [33m[ TEST ][0m it is 7 for 'Troupe!'      [32m[ PASS ][0m it is 7 for 'Troupe!'
-  [34mend [0m
-  [34mbegin [0msub
-      [33m[ TEST ][0m it is 'H' for 0      [32m[ PASS ][0m it is 'H' for 0
-      [33m[ TEST ][0m it is 'e' for 1      [32m[ PASS ][0m it is 'e' for 1
-      [33m[ TEST ][0m it is 'l' for 2      [32m[ PASS ][0m it is 'l' for 2
-      [33m[ TEST ][0m it is 'l' for 3      [32m[ PASS ][0m it is 'l' for 3
-      [33m[ TEST ][0m it is 'o' for 4      [32m[ PASS ][0m it is 'o' for 4
-      [33m[ TEST ][0m it is ''  for 5      [32m[ PASS ][0m it is ''  for 5
-      [33m[ TEST ][0m it is ''  for 6      [32m[ PASS ][0m it is ''  for 6
-  [34mend [0m
-  [34mbegin [0msubCode
-      [33m[ TEST ][0m it is 87 for 0      [32m[ PASS ][0m it is 87 for 0
-      [33m[ TEST ][0m it is 111 for 1      [32m[ PASS ][0m it is 111 for 1
-      [33m[ TEST ][0m it is 114 for 2      [32m[ PASS ][0m it is 114 for 2
-      [33m[ TEST ][0m it is 108 for 3      [32m[ PASS ][0m it is 108 for 3
-      [33m[ TEST ][0m it is 100 for 4      [32m[ PASS ][0m it is 100 for 4
-      [33m[ TEST ][0m it is 33  for 5      [32m[ PASS ][0m it is 33  for 5
-      [33m[ TEST ][0m it is 0   for 6      [32m[ PASS ][0m it is 0   for 6
-  [34mend [0m
-  [34mbegin [0msubstring
-      [33m[ TEST ][0m it is 'Hello' for 0 5      [32m[ PASS ][0m it is 'Hello' for 0 5
-      [33m[ TEST ][0m it is 'Troupe' for 6 12      [32m[ PASS ][0m it is 'Troupe' for 6 12
-      [33m[ TEST ][0m it is 'Troupe!' for 6 13      [32m[ PASS ][0m it is 'Troupe!' for 6 13
-      [33m[ TEST ][0m it is 'Troupe!' for 6 14      [32m[ PASS ][0m it is 'Troupe!' for 6 14
-  [34mend [0m
-  [34mbegin [0mconcat
-      [33m[ TEST ][0m it is '' for []      [32m[ PASS ][0m it is '' for []
-      [33m[ TEST ][0m it is 'a' for ['a']      [32m[ PASS ][0m it is 'a' for ['a']
-      [33m[ TEST ][0m it is 'a' for ['', 'a']      [32m[ PASS ][0m it is 'a' for ['', 'a']
-      [33m[ TEST ][0m it is 'a' for ['a', '']      [32m[ PASS ][0m it is 'a' for ['a', '']
-      [33m[ TEST ][0m it is 'ab' for ['a', 'b']      [32m[ PASS ][0m it is 'ab' for ['a', 'b']
-  [34mend [0m
-  [34mbegin [0mconcatWith
-      [33m[ TEST ][0m it is '' for []      [32m[ PASS ][0m it is '' for []
-      [33m[ TEST ][0m it skips separator for ['a']      [32m[ PASS ][0m it skips separator for ['a']
-      [33m[ TEST ][0m it skips separator for ['b']      [32m[ PASS ][0m it skips separator for ['b']
-      [33m[ TEST ][0m it adds separator for ['a', 'b']      [32m[ PASS ][0m it adds separator for ['a', 'b']
-      [33m[ TEST ][0m it adds separator for ['a', 'b', 'c']      [32m[ PASS ][0m it adds separator for ['a', 'b', 'c']
-      [33m[ TEST ][0m it adds separator around '' too      [32m[ PASS ][0m it adds separator around '' too
-  [34mend [0m
-  [34mbegin [0mimplode
-      [33m[ TEST ][0m it is '' for []      [32m[ PASS ][0m it is '' for []
-      [33m[ TEST ][0m it is 'a' for ['a']      [32m[ PASS ][0m it is 'a' for ['a']
-      [33m[ TEST ][0m it is 'b' for ['b']      [32m[ PASS ][0m it is 'b' for ['b']
-      [33m[ TEST ][0m it is 'ab' for ['a','b']      [32m[ PASS ][0m it is 'ab' for ['a','b']
-      [33m[ TEST ][0m it is 'ba' for ['b','a']      [32m[ PASS ][0m it is 'ba' for ['b','a']
-  [34mend [0m
-  [34mbegin [0mexplode
-      [33m[ TEST ][0m it is [] for ''      [32m[ PASS ][0m it is [] for ''
-      [33m[ TEST ][0m it is ['a'] for 'a'      [32m[ PASS ][0m it is ['a'] for 'a'
-      [33m[ TEST ][0m it is ['b'] for 'b'      [32m[ PASS ][0m it is ['b'] for 'b'
-      [33m[ TEST ][0m it is ['a','b'] for 'ab'      [32m[ PASS ][0m it is ['a','b'] for 'ab'
-      [33m[ TEST ][0m it is ['b','a'] for 'ba'      [32m[ PASS ][0m it is ['b','a'] for 'ba'
-  [34mend [0m
-  [34mbegin [0mmap
-      [33m[ TEST ][0m it is '' for ''      [32m[ PASS ][0m it is '' for ''
-      [33m[ TEST ][0m it is 'b' for 'a'      [32m[ PASS ][0m it is 'b' for 'a'
-      [33m[ TEST ][0m it is 'a' for 'b'      [32m[ PASS ][0m it is 'a' for 'b'
-      [33m[ TEST ][0m it is 'ba' for 'ab'      [32m[ PASS ][0m it is 'ba' for 'ab'
-      [33m[ TEST ][0m it is 'a b' for 'b a'      [32m[ PASS ][0m it is 'a b' for 'b a'
-  [34mend [0m
-  [34mbegin [0mtranslate
-      [33m[ TEST ][0m it is '' for ''      [32m[ PASS ][0m it is '' for ''
-      [33m[ TEST ][0m it is 'a_' for 'a'      [32m[ PASS ][0m it is 'a_' for 'a'
-      [33m[ TEST ][0m it is 'b_' for 'b'      [32m[ PASS ][0m it is 'b_' for 'b'
-      [33m[ TEST ][0m it is 'a_b_' for 'ab'      [32m[ PASS ][0m it is 'a_b_' for 'ab'
-      [33m[ TEST ][0m it is 'b_a_' for 'ba'      [32m[ PASS ][0m it is 'b_a_' for 'ba'
-  [34mend [0m
-[34mend [0m
-
-Total:  54
-Passes: 54
->>> Main thread finished with value: true@{}%{}

--- a/tests/lib/String.trp
+++ b/tests/lib/String.trp
@@ -9,6 +9,14 @@ let val tests = Unit.group "String" [
               , Unit.it "is 5 for 'Hello'"    (Unit.isEq 5 (String.size "Hello"))
               , Unit.it "is 7 for 'Troupe!'"  (Unit.isEq 7 (String.size "Troupe!"))
             ],
+            let val s = "Hello Troupe!"
+            in Unit.group "substring" [
+                    Unit.it "is 'Hello' for 0 5"    (Unit.isEq "Hello"   (String.substring (s, 0, 5)))
+                  , Unit.it "is 'Troupe' for 6 12"  (Unit.isEq "Troupe"  (String.substring (s, 6, 12)))
+                  , Unit.it "is 'Troupe!' for 6 13" (Unit.isEq "Troupe!" (String.substring (s, 6, 13)))
+                  , Unit.it "is 'Troupe!' for 6 14" (Unit.isEq "Troupe!" (String.substring (s, 6, 14)))
+                ]
+            end,
             let val s = "Hello"
             in Unit.group "sub" [
                     Unit.it "is 'H' for 0" (Unit.isEq "H" (String.sub s 0))
@@ -29,14 +37,6 @@ let val tests = Unit.group "String" [
                   , Unit.it "is 100 for 4" (Unit.isEq 100 (String.subCode s 4))
                   , Unit.it "is 33  for 5" (Unit.isEq 33  (String.subCode s 5))
                   , Unit.it "is 0   for 6" (Unit.isEq 0   (String.subCode s 6))
-                ]
-            end,
-            let val s = "Hello Troupe!"
-            in Unit.group "substring" [
-                    Unit.it "is 'Hello' for 0 5"    (Unit.isEq "Hello"   (String.substring s 0 5))
-                  , Unit.it "is 'Troupe' for 6 12"  (Unit.isEq "Troupe"  (String.substring s 6 12))
-                  , Unit.it "is 'Troupe!' for 6 13" (Unit.isEq "Troupe!" (String.substring s 6 13))
-                  , Unit.it "is 'Troupe!' for 6 14" (Unit.isEq "Troupe!" (String.substring s 6 14))
                 ]
             end,
             Unit.group "concat" [

--- a/tests/lib/String.trp
+++ b/tests/lib/String.trp
@@ -19,24 +19,24 @@ let val tests = Unit.group "String" [
             end,
             let val s = "Hello"
             in Unit.group "sub" [
-                    Unit.it "is 'H' for 0" (Unit.isEq "H" (String.sub s 0))
-                  , Unit.it "is 'e' for 1" (Unit.isEq "e" (String.sub s 1))
-                  , Unit.it "is 'l' for 2" (Unit.isEq "l" (String.sub s 2))
-                  , Unit.it "is 'l' for 3" (Unit.isEq "l" (String.sub s 3))
-                  , Unit.it "is 'o' for 4" (Unit.isEq "o" (String.sub s 4))
-                  , Unit.it "is ''  for 5" (Unit.isEq ""  (String.sub s 5))
-                  , Unit.it "is ''  for 6" (Unit.isEq ""  (String.sub s 6))
+                    Unit.it "is 'H' for 0" (Unit.isEq "H" (String.sub (s, 0)))
+                  , Unit.it "is 'e' for 1" (Unit.isEq "e" (String.sub (s, 1)))
+                  , Unit.it "is 'l' for 2" (Unit.isEq "l" (String.sub (s, 2)))
+                  , Unit.it "is 'l' for 3" (Unit.isEq "l" (String.sub (s, 3)))
+                  , Unit.it "is 'o' for 4" (Unit.isEq "o" (String.sub (s, 4)))
+                  , Unit.it "is ''  for 5" (Unit.isEq ""  (String.sub (s, 5)))
+                  , Unit.it "is ''  for 6" (Unit.isEq ""  (String.sub (s, 6)))
                 ]
             end,
             let val s = "World!"
             in Unit.group "subCode" [
-                    Unit.it "is 87 for 0"  (Unit.isEq 87  (String.subCode s 0))
-                  , Unit.it "is 111 for 1" (Unit.isEq 111 (String.subCode s 1))
-                  , Unit.it "is 114 for 2" (Unit.isEq 114 (String.subCode s 2))
-                  , Unit.it "is 108 for 3" (Unit.isEq 108 (String.subCode s 3))
-                  , Unit.it "is 100 for 4" (Unit.isEq 100 (String.subCode s 4))
-                  , Unit.it "is 33  for 5" (Unit.isEq 33  (String.subCode s 5))
-                  , Unit.it "is 0   for 6" (Unit.isEq 0   (String.subCode s 6))
+                    Unit.it "is 87 for 0"  (Unit.isEq 87  (String.subCode (s, 0)))
+                  , Unit.it "is 111 for 1" (Unit.isEq 111 (String.subCode (s, 1)))
+                  , Unit.it "is 114 for 2" (Unit.isEq 114 (String.subCode (s, 2)))
+                  , Unit.it "is 108 for 3" (Unit.isEq 108 (String.subCode (s, 3)))
+                  , Unit.it "is 100 for 4" (Unit.isEq 100 (String.subCode (s, 4)))
+                  , Unit.it "is 33  for 5" (Unit.isEq 33  (String.subCode (s, 5)))
+                  , Unit.it "is 0   for 6" (Unit.isEq 0   (String.subCode (s, 6)))
                 ]
             end,
             Unit.group "concat" [


### PR DESCRIPTION
"Undos" the change from 181fff7e7 and makes `String.sub` and `String.subCode` match. A few other TODOs were also added/updated/removed along the way.