### PR TITLE
feat: additional IFC utilities in `Missing` (for Facetted Values)

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,6 +3,9 @@ COMPILER=../bin/troupec
 build:
 	mkdir -p out
 
+  # Transition hack; 2025-12-14; AA
+	$(COMPILER) ./Missing.trp -l
+
   # No dependencies
 	$(COMPILER) ./Number.trp -l
 	$(COMPILER) ./List.trp -l
@@ -35,9 +38,6 @@ build:
   # Dependency on `List`, `ListPair`, and `StencilVector`
 	$(COMPILER) ./HashMap.trp -l
 	$(COMPILER) ./HashSet.trp -l
-
-  # Transition hack; 2025-12-14; AA 
-	$(COMPILER) ./Missing.trp -l 
 
 clean:
 	rm -rf out

--- a/lib/Missing.trp
+++ b/lib/Missing.trp
@@ -7,6 +7,17 @@ let
         otherwise returns unit. *)
     fun invokeWithTaint lev f = if true raisedTo lev then f() else ()
 
+    (** Raise the blocking level to `level`. *)
+    fun raiseBL level = ((if (true raisedTo level) then () else ()); ())
+
+    (** Runs `f` while preserving the blocking level regardless of any downgrades in `f`. *)
+    fun preserveBL f =
+        let val bl = _bl ()
+            val x = f ()
+            val _ = raiseBL bl
+        in x
+        end
+
     (* TODO: The `downgradeDeep` below ought to be refactored into `DeclassifyUtil`. *)
 
     (* Mutually recursive deep downgrade of tuples *)
@@ -45,6 +56,8 @@ let
         end
 
 in [ ("invokeWithTaint", invokeWithTaint)
+   , ("raiseBL", raiseBL)
+   , ("preserveBL", preserveBL)
    , ("downgradeDeep", downgradeDeep)
    ]
 end

--- a/lib/Missing.trp
+++ b/lib/Missing.trp
@@ -7,6 +7,8 @@ let
         otherwise returns unit. *)
     fun invokeWithTaint lev f = if true raisedTo lev then f() else ()
 
+    (* TODO: The `downgradeDeep` below ought to be refactored into `DeclassifyUtil`. *)
+
     (* Mutually recursive deep downgrade of tuples *)
     fun downgrade2 ((x,y), a, lev) =
         ( downgradeDeep (x, a, lev)


### PR DESCRIPTION
As I've been trying to design a library for *facetted values* (as a precursor for a facetted HashMap), I extended the `Missing` library with a few more functions of potential interest.