### PR TITLE
Fix multinode test failures: quarantine-echo and ring-echo-5

### DIFF
--- a/examples/network/qauth/auth-server.trp
+++ b/examples/network/qauth/auth-server.trp
@@ -69,17 +69,17 @@ let
                          print "AUTH SERVER: Authentication SUCCESSFUL";
                          (* --- convenience hack : avoids unnecessary quarantining on the client side *)
                          invokeAtLevel
-                             (`<alice; alice>`,
-                              (fn () => send ( reply_to
-                                             , ("AUTH_RESULT", public_result raisedTo `<;alice>`)))
+                             ((fn () => send ( reply_to
+                                             , ("AUTH_RESULT", public_result raisedTo `<;alice>`))),
+                              `<alice; alice>`)
 
                     else print "AUTH SERVER: Authentication FAILED";
                          (* --- convenience hack : avoids unnecessary quarantining on the client side *)
                          invokeAtLevel
-                             (token_level,
-                              (fn () =>
+                             ((fn () =>
                                   send( reply_to
-                                      , ("AUTH_RESULT", public_result), sender_meta.quarantineAuth))
+                                      , ("AUTH_RESULT", public_result), sender_meta.quarantineAuth)),
+                              token_level)
 
             val _ = print "AUTH SERVER: Sent auth result"
         in ()

--- a/examples/network/quarantine-echo-01/qecho-server.trp
+++ b/examples/network/quarantine-echo-01/qecho-server.trp
@@ -65,8 +65,8 @@ let
                                 (* val msg' = downgrade (msg, quarantineAuth, `<;>`) *)
                                 (* val _ = printWithLabels msg *)
                                 val _ = debugpc ()
-                                val _ = invokeAtLevel (levelOf msg,
-                                                       fn () => send(sender, ("REPLY", msg), quarantineAuth))
+                                val _ = invokeAtLevel (fn () => send(sender, ("REPLY", msg), quarantineAuth),
+                                                       levelOf msg)
                                 val _ = print "SERVER: Sent reply"
                             in ()
                             end

--- a/tests/rt/multinode-tests/quarantine-echo/qecho-server.trp
+++ b/tests/rt/multinode-tests/quarantine-echo/qecho-server.trp
@@ -32,8 +32,8 @@ let
 in case (x', y') of
     (("ECHO", msg, sender), {quarantineAuth, ..}) =>
         let val _ = print "SERVER: Sending reply with quarantine authority"
-            val _ = invokeAtLevel ( levelOf msg
-                                  , fn () => send(sender, ("REPLY", msg), quarantineAuth))
+            val _ = invokeAtLevel ( fn () => send(sender, ("REPLY", msg), quarantineAuth)
+                                  , levelOf msg)
             val _ = sleep 1000
             val _ = print "SERVER: Done"
         in exit(authority, 0)

--- a/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/echo-client.trp
@@ -1,6 +1,6 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/echo-server.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/echo-server.trp
@@ -1,6 +1,6 @@
 let 
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary1.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary2.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary3.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary4.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     

--- a/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
+++ b/tests/rt/multinode-tests/ring-echo-5/intermediary5.trp
@@ -1,6 +1,6 @@
 let
     val timeout_pid = spawn(fn () => 
-        let val _ = sleep 10000
+        let val _ = sleep 30000
         in exit(authority, 124)
         end)
     


### PR DESCRIPTION
## Summary
- **quarantine-echo**: Fix reversed arguments to `invokeAtLevel(f, level)` — callers were passing `(level, f)` instead of `(f, level)`, causing `"value fn => .. is not a level"` errors
- **ring-echo-5**: Increase internal Troupe-level timeout from 10s to 30s in all 7 node scripts to prevent flaky CI failures (the CI timeout multiplier doesn't affect in-program `sleep` calls)
- Also fixes the same reversed `invokeAtLevel` pattern in `examples/network/quarantine-echo-01/` and `examples/network/qauth/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)