### PR TITLE
Add --result-socket CLI for structured IPC

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y libnuma-dev diffutils
+          sudo apt-get install -y libnuma-dev diffutils socat
       
       # Cache GHC installation
       - name: Cache GHC

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ci-test-golden-no-color:
 	mkdir -p out 
 	./bin/golden --no-color
 
-test: test/local test/multinode
+test: test/local test/multinode test/result-socket
 test/local:
 	mkdir -p out
 	cd compiler && $(MAKE) test
@@ -61,6 +61,13 @@ test/libp2p-migration-verbose:
 test/ci-network: rt p2p-tools
 	@echo "Running CI network test..."
 	./tests/ci-network-test.sh
+test/result-socket: test/result-socket-socat test/result-socket-node
+test/result-socket-socat:
+	@command -v socat >/dev/null 2>&1 || { echo "SKIP: socat not installed"; exit 0; }
+	bash tests/rt/result-socket/test-result-socket.sh
+test/result-socket-node:
+	node tests/rt/result-socket/test-result-socket.mjs
+
 test/ci-relay: p2p-tools
 	@echo "Running CI relay test..."
 	./tests/ci-relay-test.sh

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,11 @@ test/ci-network: rt p2p-tools
 	./tests/ci-network-test.sh
 test/result-socket: test/result-socket-socat test/result-socket-node
 test/result-socket-socat:
-	@command -v socat >/dev/null 2>&1 || { echo "SKIP: socat not installed"; exit 0; }
-	bash tests/rt/result-socket/test-result-socket.sh
+	@if command -v socat >/dev/null 2>&1; then \
+		bash tests/rt/result-socket/test-result-socket.sh; \
+	else \
+		echo "SKIP: socat not installed"; \
+	fi
 test/result-socket-node:
 	node tests/rt/result-socket/test-result-socket.mjs
 

--- a/rt/src/Scheduler.mts
+++ b/rt/src/Scheduler.mts
@@ -12,6 +12,7 @@ import SandboxStatus from './SandboxStatus.mjs'
 import  {ThreadError, TroupeError} from './TroupeError.mjs'
 import  {lub} from './Level.mjs'
 import { getCliArgs, TroupeCliArg } from './TroupeCliArgs.mjs';
+import { sendSocketMessage, isResultSocketEnabled } from './resultSocket.mjs';
 
 import {SYSTEM_PROCESS_STRING} from './Constants.mjs'
 const argv = getCliArgs();
@@ -90,7 +91,8 @@ export class Scheduler implements SchedulerInterface {
         this.notifyMonitors ();
 
         delete this.__alive[this.currentThreadId.val.toString()];
-        if (!argv[TroupeCliArg.SuppressMainThreadFinishedMessage]) {
+        sendSocketMessage({ type: 'main-thread-result', value: retVal.stringRep() });
+        if (!argv[TroupeCliArg.SuppressMainThreadFinishedMessage] && !isResultSocketEnabled()) {
             console.log(">>> Main thread finished with value:", retVal.stringRep());
         }
         if (persist) {

--- a/rt/src/TroupeCliArgs.mts
+++ b/rt/src/TroupeCliArgs.mts
@@ -55,6 +55,7 @@ export enum TroupeCliArg {
     Explain = 'explain',
     Timeout = 'timeout',
     TimeoutExitCode = 'timeout-exit-code',
+    ResultSocket = 'result-socket',
 }
 
 export interface ParsedArgs {
@@ -87,6 +88,7 @@ export interface ParsedArgs {
     [TroupeCliArg.Explain]?: boolean;
     [TroupeCliArg.Timeout]?: number;
     [TroupeCliArg.TimeoutExitCode]?: number;
+    [TroupeCliArg.ResultSocket]?: string;
     [key: string]: any;
 }
 
@@ -172,6 +174,10 @@ export function getCliArgs(): ParsedArgs {
                 type: 'number',
                 default: 124,
                 describe: 'Exit code to use when execution times out'
+            })
+            .option(TroupeCliArg.ResultSocket, {
+                type: 'string',
+                describe: 'Unix socket path for structured lifecycle messages (main thread result, process exit)'
             })
             .parseSync();
 

--- a/rt/src/builtins/exit.mts
+++ b/rt/src/builtins/exit.mts
@@ -2,6 +2,7 @@ import { UserRuntimeZero, Constructor, mkBase } from './UserRuntimeZero.mjs'
 import { assertNormalState, assertIsNTuple, assertIsAuthority, assertIsNumber, assertIsRootAuthority } from '../Asserts.mjs'
 import { __unit } from '../UnitVal.mjs';
 import { setExitInitiated } from '../runtimeMonitored.mjs';
+import { sendSocketMessageAndClose } from '../resultSocket.mjs';
 
 
 export function BuiltinExit <TBase extends Constructor<UserRuntimeZero>>(Base: TBase) {
@@ -15,6 +16,7 @@ export function BuiltinExit <TBase extends Constructor<UserRuntimeZero>>(Base: T
             assertIsRootAuthority(arg.val[0]);
             setExitInitiated();  // Prevent compiler exit handler from interfering
             (async () => {
+                await sendSocketMessageAndClose({ type: 'process-exit', exitCode: arg.val[1].val });
                 await $r.cleanup()
                 process.exit(arg.val[1].val);
             }) ()

--- a/rt/src/resultSocket.mts
+++ b/rt/src/resultSocket.mts
@@ -1,0 +1,97 @@
+'use strict'
+import * as net from 'node:net';
+import { getCliArgs, TroupeCliArg } from './TroupeCliArgs.mjs';
+
+export interface SocketMessage {
+    type: 'main-thread-result' | 'process-exit' | 'error';
+    value?: string;
+    exitCode?: number;
+    reason?: string;
+    message?: string;
+}
+
+let client: net.Socket | null = null;
+
+/**
+ * Returns true if --result-socket was provided on the command line.
+ */
+export function isResultSocketEnabled(): boolean {
+    return !!getCliArgs()[TroupeCliArg.ResultSocket];
+}
+
+/**
+ * Connects to the Unix socket specified by --result-socket.
+ * No-op if --result-socket was not provided.
+ * On connection error: warns to stderr and resolves (never blocks startup).
+ * The socket is unref()'d so it doesn't prevent natural process exit.
+ */
+export function connectResultSocket(): Promise<void> {
+    const socketPath = getCliArgs()[TroupeCliArg.ResultSocket];
+    if (!socketPath) return Promise.resolve();
+
+    return new Promise<void>((resolve) => {
+        client = net.createConnection({ path: socketPath }, () => {
+            client!.unref();
+            resolve();
+        });
+        client.on('error', (err) => {
+            console.error(`Warning: could not connect to result socket ${socketPath}: ${err.message}`);
+            client = null;
+            resolve();
+        });
+    });
+}
+
+/**
+ * Writes a JSON message to the socket, handling backpressure.
+ * If write() returns false (kernel buffer full), waits for the 'drain' event.
+ */
+async function writeMessage(msg: SocketMessage): Promise<void> {
+    if (!client || client.destroyed || client.writableEnded) return;
+    client.ref();  // Ensure the event loop stays alive for the write
+    const data = JSON.stringify(msg) + '\n';
+    return new Promise<void>((resolve, reject) => {
+        const ok = client!.write(data);
+        if (ok) {
+            resolve();
+        } else {
+            client!.once('drain', resolve);
+            client!.once('error', reject);
+        }
+    });
+}
+
+/**
+ * Sends a message over the socket. No-op if not connected.
+ * Catches and logs errors without throwing.
+ */
+export async function sendSocketMessage(msg: SocketMessage): Promise<void> {
+    if (!client || client.destroyed || client.writableEnded) return;
+    try {
+        await writeMessage(msg);
+    } catch (err: any) {
+        console.error(`Warning: failed to write to result socket: ${err.message}`);
+    }
+}
+
+/**
+ * Sends a final message, flushes, and closes the connection.
+ * Used for the process-exit message before process.exit().
+ */
+export async function sendSocketMessageAndClose(msg: SocketMessage): Promise<void> {
+    if (!client || client.destroyed || client.writableEnded) return;
+    try {
+        await writeMessage(msg);
+    } catch (err: any) {
+        console.error(`Warning: failed to write to result socket: ${err.message}`);
+    }
+    return new Promise<void>((resolve) => {
+        if (!client || client.destroyed || client.writableEnded) {
+            resolve();
+            return;
+        }
+        client.end(() => {
+            resolve();
+        });
+    });
+}

--- a/rt/src/runtimeMonitored.mts
+++ b/rt/src/runtimeMonitored.mts
@@ -28,6 +28,7 @@ import { Console } from 'node:console'
 
 const { flowsTo, actsFor, lub, glb } = levels
 import { getCliArgs, TroupeCliArg } from './TroupeCliArgs.mjs';
+import { connectResultSocket, sendSocketMessageAndClose } from './resultSocket.mjs';
 import { configureColors, isColorEnabled } from './colorConfig.mjs';
 import { mkLogger } from './logger.mjs'
 import { getTroupeRoot } from './troupeRoot.mjs'
@@ -447,6 +448,7 @@ setRuntimeObject(__rtObj)
 
 
 async function cleanupAsync() {
+  await sendSocketMessageAndClose({ type: 'process-exit', exitCode: 0 });
   closeReadline()
   DS.stopCompiler();
   if (__p2pRunning) {
@@ -475,6 +477,7 @@ function bulletProofSigint() {
   process.on('SIGINT', () => {
     debug("SIGINT");
     (async () => {
+      await sendSocketMessageAndClose({ type: 'process-exit', exitCode: 0 });
       await cleanupAsync()
       process.exit(0);
     })()
@@ -548,6 +551,7 @@ async function getNetworkPeerId(rtHandlers) {
 }
 
 export async function start(f) {
+  await connectResultSocket();
   await initTrustMap()
 
   let peerid = await getNetworkPeerId({
@@ -607,6 +611,7 @@ export async function start(f) {
     const timer = setTimeout(async () => {
       console.error(`Execution timed out after ${timeoutSeconds} seconds`);
       setExitInitiated();
+      await sendSocketMessageAndClose({ type: 'process-exit', exitCode, reason: 'timeout' });
       await cleanupAsync();
       process.exit(exitCode);
     }, timeoutSeconds * 1000);

--- a/tests/rt/result-socket/longrunning.trp
+++ b/tests/rt/result-socket/longrunning.trp
@@ -1,0 +1,5 @@
+let fun loop () = let val _ = sleep 100
+                  in loop ()
+                  end
+in loop ()
+end

--- a/tests/rt/result-socket/multithread.trp
+++ b/tests/rt/result-socket/multithread.trp
@@ -1,0 +1,6 @@
+let fun worker () =
+      receive [hn x => x]
+    val p = spawn worker
+in send (p, "done");
+   100
+end

--- a/tests/rt/result-socket/simple.trp
+++ b/tests/rt/result-socket/simple.trp
@@ -1,0 +1,3 @@
+let val x = 42
+in x
+end

--- a/tests/rt/result-socket/test-result-socket.mjs
+++ b/tests/rt/result-socket/test-result-socket.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Automated tests for the --result-socket CLI feature.
+ * Tests that the Troupe runtime communicates lifecycle events
+ * through a Unix domain socket.
+ */
+
+import * as net from 'node:net';
+import { spawn, execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+
+// Walk up from this file's directory to find the repo root (marked by .troupe-root)
+function findTroupeRoot() {
+    let dir = resolve(import.meta.dirname, '..', '..', '..');
+    // Verify we found the right root by checking for .troupe-root marker
+    if (existsSync(join(dir, '.troupe-root'))) return dir;
+    // Fallback: walk up further (e.g., in worktrees)
+    let parent = resolve(dir, '..');
+    while (parent !== dir) {
+        if (existsSync(join(parent, '.troupe-root'))) return parent;
+        dir = parent;
+        parent = resolve(dir, '..');
+    }
+    // Last resort: use the relative path
+    return resolve(import.meta.dirname, '..', '..', '..');
+}
+
+const TROUPE_ROOT = findTroupeRoot();
+const TROUPEC = join(TROUPE_ROOT, 'bin', 'troupec');
+const RUNTIME = join(TROUPE_ROOT, 'rt', 'built', 'troupe.mjs');
+const TEST_DIR = import.meta.dirname;
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(`Assertion failed: ${message}`);
+    }
+}
+
+/**
+ * Compiles a .trp file to .js, returns the output path.
+ */
+function compile(trpFile) {
+    const outFile = join(tmpdir(), `troupe-test-${randomUUID().slice(0, 8)}.js`);
+    execSync(`"${TROUPEC}" "${trpFile}" --output="${outFile}"`, {
+        env: { ...process.env, TROUPE: TROUPE_ROOT },
+        stdio: 'pipe',
+    });
+    return outFile;
+}
+
+/**
+ * Creates a Unix socket server, runs the runtime with --result-socket,
+ * and collects all messages + stdout/stderr.
+ *
+ * Returns { messages, stdout, stderr, exitCode }
+ */
+function runWithSocket(jsFile, extraArgs = []) {
+    return new Promise(async (resolveTest) => {
+        const socketPath = join(tmpdir(), `troupe-test-sock-${randomUUID().slice(0, 8)}.sock`);
+        await unlink(socketPath).catch(() => {});
+
+        const messages = [];
+        let stdout = '';
+        let stderr = '';
+        let socketBuffer = '';
+
+        const server = net.createServer((conn) => {
+            conn.on('data', (chunk) => {
+                socketBuffer += chunk.toString();
+                let idx;
+                while ((idx = socketBuffer.indexOf('\n')) !== -1) {
+                    const line = socketBuffer.slice(0, idx);
+                    socketBuffer = socketBuffer.slice(idx + 1);
+                    if (!line) continue;
+                    try {
+                        messages.push(JSON.parse(line));
+                    } catch {}
+                }
+            });
+        });
+
+        await new Promise((res) => server.listen(socketPath, res));
+
+        const args = [
+            '--stack-trace-limit=1000',
+            RUNTIME,
+            '-f=' + jsFile,
+            '--localonly',
+            '--suppress-local-info-message',
+            `--result-socket=${socketPath}`,
+            ...extraArgs,
+        ];
+
+        const proc = spawn('node', args, {
+            env: { ...process.env, TROUPE: TROUPE_ROOT },
+        });
+
+        proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+        proc.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+
+        proc.on('close', (code) => {
+            server.close();
+            unlink(socketPath).catch(() => {});
+            unlink(jsFile).catch(() => {});
+            resolveTest({ messages, stdout, stderr, exitCode: code ?? 0 });
+        });
+
+        // Safety timeout
+        setTimeout(() => {
+            proc.kill('SIGKILL');
+        }, 30000);
+    });
+}
+
+/**
+ * Runs the runtime WITHOUT --result-socket and captures stdout.
+ */
+function runWithoutSocket(jsFile, extraArgs = []) {
+    return new Promise((resolveTest) => {
+        const args = [
+            '--stack-trace-limit=1000',
+            RUNTIME,
+            '-f=' + jsFile,
+            '--localonly',
+            '--suppress-local-info-message',
+            ...extraArgs,
+        ];
+
+        let stdout = '';
+        let stderr = '';
+
+        const proc = spawn('node', args, {
+            env: { ...process.env, TROUPE: TROUPE_ROOT },
+        });
+
+        proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+        proc.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+
+        proc.on('close', (code) => {
+            unlink(jsFile).catch(() => {});
+            resolveTest({ stdout, stderr, exitCode: code ?? 0 });
+        });
+
+        setTimeout(() => {
+            proc.kill('SIGKILL');
+        }, 30000);
+    });
+}
+
+async function test(name, fn) {
+    try {
+        await fn();
+        passed++;
+        console.log(`  PASS: ${name}`);
+    } catch (err) {
+        failed++;
+        console.log(`  FAIL: ${name}`);
+        console.log(`        ${err.message}`);
+    }
+}
+
+// ---- Tests ----
+
+console.log('Result Socket Tests');
+console.log('===================');
+
+await test('Simple program: receives main-thread-result and process-exit', async () => {
+    const jsFile = compile(join(TEST_DIR, 'simple.trp'));
+    const { messages, stdout } = await runWithSocket(jsFile);
+
+    const resultMsg = messages.find(m => m.type === 'main-thread-result');
+    assert(resultMsg, 'should receive a main-thread-result message');
+    assert(resultMsg.value.includes('42'), `result value should contain 42, got: ${resultMsg.value}`);
+
+    const exitMsg = messages.find(m => m.type === 'process-exit');
+    assert(exitMsg, 'should receive a process-exit message');
+    assert(exitMsg.exitCode === 0, `exit code should be 0, got: ${exitMsg.exitCode}`);
+
+    assert(!stdout.includes('Main thread finished'), 'stdout should NOT contain "Main thread finished" when socket is used');
+});
+
+await test('Simple program: message ordering (result before exit)', async () => {
+    const jsFile = compile(join(TEST_DIR, 'simple.trp'));
+    const { messages } = await runWithSocket(jsFile);
+
+    const resultIdx = messages.findIndex(m => m.type === 'main-thread-result');
+    const exitIdx = messages.findIndex(m => m.type === 'process-exit');
+    assert(resultIdx >= 0, 'should have main-thread-result');
+    assert(exitIdx >= 0, 'should have process-exit');
+    assert(resultIdx < exitIdx, `main-thread-result (idx ${resultIdx}) should come before process-exit (idx ${exitIdx})`);
+});
+
+await test('Multi-thread: main finishes before child thread drains', async () => {
+    const jsFile = compile(join(TEST_DIR, 'multithread.trp'));
+    const { messages } = await runWithSocket(jsFile);
+
+    const resultMsg = messages.find(m => m.type === 'main-thread-result');
+    assert(resultMsg, 'should receive a main-thread-result message');
+    assert(resultMsg.value.includes('100'), `result value should contain 100, got: ${resultMsg.value}`);
+
+    const exitMsg = messages.find(m => m.type === 'process-exit');
+    assert(exitMsg, 'should receive a process-exit message');
+    assert(exitMsg.exitCode === 0, `exit code should be 0, got: ${exitMsg.exitCode}`);
+});
+
+await test('Timeout: sends process-exit with reason timeout', async () => {
+    const jsFile = compile(join(TEST_DIR, 'longrunning.trp'));
+    const { messages, exitCode } = await runWithSocket(jsFile, ['--timeout=1']);
+
+    const exitMsg = messages.find(m => m.type === 'process-exit');
+    assert(exitMsg, 'should receive a process-exit message');
+    assert(exitMsg.exitCode === 124, `exit code should be 124, got: ${exitMsg.exitCode}`);
+    assert(exitMsg.reason === 'timeout', `reason should be "timeout", got: ${exitMsg.reason}`);
+    assert(exitCode === 124, `process exit code should be 124, got: ${exitCode}`);
+});
+
+await test('Regression: stdout shows "Main thread finished" without --result-socket', async () => {
+    const jsFile = compile(join(TEST_DIR, 'simple.trp'));
+    const { stdout } = await runWithoutSocket(jsFile);
+
+    assert(stdout.includes('Main thread finished'), 'stdout should contain "Main thread finished" when socket is NOT used');
+    assert(stdout.includes('42'), `stdout should contain the value 42, got: ${stdout}`);
+});
+
+// ---- Summary ----
+
+console.log('');
+console.log(`Results: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/rt/result-socket/test-result-socket.sh
+++ b/tests/rt/result-socket/test-result-socket.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+#
+# Shell-based tests for --result-socket using socat.
+# These tests verify both CLI behavior and socket data content,
+# providing complementary coverage to test-result-socket.mjs (Node.js).
+#
+# Prerequisite: socat must be installed.
+# - Linux: apt install socat
+# - macOS: brew install socat
+#
+
+set -e
+
+# Source troupe-env.sh to get TROUPE_ROOT (handles worktrees and .troupe-root marker)
+. "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/troupe-env.sh"
+TROUPEC="$TROUPE_ROOT/bin/troupec"
+RUNTIME="$TROUPE_ROOT/rt/built/troupe.mjs"
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PASSED=0
+FAILED=0
+TMPDIR_ROOT=""
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "        $2"
+    fi
+}
+
+# Create a fresh temp directory for each test
+make_tmpdir() {
+    TMPDIR_ROOT=$(mktemp -d /tmp/troupe-socat-test-XXXXXXXX)
+}
+
+cleanup_tmpdir() {
+    rm -rf "$TMPDIR_ROOT"
+}
+
+compile() {
+    local trp="$1"
+    local out="$TMPDIR_ROOT/program.js"
+    "$TROUPEC" "$trp" --output="$out" 2>/dev/null
+    echo "$out"
+}
+
+# Helper: start a socat listener that captures socket data to a file.
+# Usage: start_socat_listener
+# Uses $TMPDIR_ROOT/test.sock and $TMPDIR_ROOT/sock-data.out
+start_socat_listener() {
+    local sock="$TMPDIR_ROOT/test.sock"
+    local outfile="$TMPDIR_ROOT/sock-data.out"
+    # -u: unidirectional mode (read from socket, write to file only)
+    # This avoids socat trying to read from the file back to the socket,
+    # which caused "read-write mode but only supports write-only" errors.
+    socat -u UNIX-LISTEN:"$sock",fork OPEN:"$outfile",creat,append 2>/dev/null &
+    SOCAT_PID=$!
+    sleep 0.3
+}
+
+stop_socat_listener() {
+    kill "$SOCAT_PID" 2>/dev/null || true
+    wait "$SOCAT_PID" 2>/dev/null || true
+}
+
+run_with_socket() {
+    local js="$1"
+    shift
+    node --stack-trace-limit=1000 "$RUNTIME" -f="$js" --localonly \
+        --suppress-local-info-message --result-socket="$TMPDIR_ROOT/test.sock" \
+        "$@" 2>/dev/null || true
+    sleep 0.3
+}
+
+run_without_socket() {
+    local js="$1"
+    shift
+    node --stack-trace-limit=1000 "$RUNTIME" -f="$js" --localonly \
+        --suppress-local-info-message \
+        "$@" 2>/dev/null || true
+}
+
+sock_data() {
+    cat "$TMPDIR_ROOT/sock-data.out" 2>/dev/null
+}
+
+echo "Result Socket Tests (socat)"
+echo "==========================="
+
+# Test 1: Regression -- stdout shows message without socket
+test_regression_stdout() {
+    local name="Regression: stdout shows 'Main thread finished' without --result-socket"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    run_without_socket "$js" > "$TMPDIR_ROOT/stdout.out"
+
+    if grep -q "Main thread finished" "$TMPDIR_ROOT/stdout.out" && grep -q "42" "$TMPDIR_ROOT/stdout.out"; then
+        pass "$name"
+    else
+        fail "$name" "expected 'Main thread finished' with value 42 on stdout"
+        cat "$TMPDIR_ROOT/stdout.out"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 2: Stdout is suppressed when --result-socket is used
+test_stdout_suppressed() {
+    local name="Stdout suppressed: 'Main thread finished' not printed when socket is used"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    start_socat_listener
+    run_with_socket "$js" > "$TMPDIR_ROOT/stdout.out"
+    stop_socat_listener
+
+    if grep -q "Main thread finished" "$TMPDIR_ROOT/stdout.out"; then
+        fail "$name" "stdout should NOT contain 'Main thread finished' when socket is used"
+        cat "$TMPDIR_ROOT/stdout.out"
+    else
+        pass "$name"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 3: Graceful degradation when socket path doesn't exist
+test_no_listener() {
+    local name="Graceful degradation: runtime runs normally if socket is unavailable"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    node --stack-trace-limit=1000 "$RUNTIME" -f="$js" --localonly \
+        --suppress-local-info-message --result-socket=/tmp/nonexistent-sock-XXXXXXXX.sock \
+        2>/dev/null
+    local exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "$name"
+    else
+        fail "$name" "expected exit code 0, got $exit_code"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 4: Receives main-thread-result with correct value
+test_main_thread_result() {
+    local name="Data: receives main-thread-result with value containing 42"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    start_socat_listener
+    run_with_socket "$js"
+    stop_socat_listener
+
+    if sock_data | grep -q '"type":"main-thread-result"' && sock_data | grep -q '"value":"42'; then
+        pass "$name"
+    else
+        fail "$name" "expected main-thread-result with value 42 in socket data"
+        echo "        socket data: $(sock_data)"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 5: Receives process-exit message
+test_process_exit() {
+    local name="Data: receives process-exit with exitCode 0"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    start_socat_listener
+    run_with_socket "$js"
+    stop_socat_listener
+
+    if sock_data | grep -q '"type":"process-exit"' && sock_data | grep -q '"exitCode":0'; then
+        pass "$name"
+    else
+        fail "$name" "expected process-exit with exitCode 0 in socket data"
+        echo "        socket data: $(sock_data)"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 6: Message ordering -- main-thread-result appears before process-exit
+test_message_ordering() {
+    local name="Data: main-thread-result appears before process-exit"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/simple.trp")
+
+    start_socat_listener
+    run_with_socket "$js"
+    stop_socat_listener
+
+    local result_line exit_line
+    result_line=$(sock_data | grep -n '"type":"main-thread-result"' | head -1 | cut -d: -f1)
+    exit_line=$(sock_data | grep -n '"type":"process-exit"' | head -1 | cut -d: -f1)
+
+    if [ -n "$result_line" ] && [ -n "$exit_line" ] && [ "$result_line" -lt "$exit_line" ]; then
+        pass "$name"
+    else
+        fail "$name" "main-thread-result (line $result_line) should appear before process-exit (line $exit_line)"
+        echo "        socket data: $(sock_data)"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 7: Multi-thread -- main finishes before spawned thread
+test_multithread() {
+    local name="Data: multi-thread program sends both messages with value 100"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/multithread.trp")
+
+    start_socat_listener
+    run_with_socket "$js"
+    stop_socat_listener
+
+    local has_result has_exit has_100
+    has_result=$(sock_data | grep -c '"type":"main-thread-result"' || true)
+    has_exit=$(sock_data | grep -c '"type":"process-exit"' || true)
+    has_100=$(sock_data | grep -c '"value":"100' || true)
+
+    if [ "$has_result" -ge 1 ] && [ "$has_exit" -ge 1 ] && [ "$has_100" -ge 1 ]; then
+        pass "$name"
+    else
+        fail "$name" "expected main-thread-result with 100 and process-exit"
+        echo "        socket data: $(sock_data)"
+    fi
+    cleanup_tmpdir
+}
+
+# Test 8: Timeout sends process-exit with reason
+test_timeout() {
+    local name="Data: timeout sends process-exit with reason 'timeout'"
+    make_tmpdir
+    local js
+    js=$(compile "$TEST_DIR/longrunning.trp")
+
+    start_socat_listener
+    run_with_socket "$js" --timeout=2
+    stop_socat_listener
+
+    if sock_data | grep -q '"type":"process-exit"' && sock_data | grep -q '"reason":"timeout"'; then
+        pass "$name"
+    else
+        fail "$name" "expected process-exit with reason 'timeout' in socket data"
+        echo "        socket data: $(sock_data)"
+    fi
+    cleanup_tmpdir
+}
+
+test_regression_stdout
+test_stdout_suppressed
+test_no_listener
+test_main_thread_result
+test_process_exit
+test_message_ordering
+test_multithread
+test_timeout
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed, $((PASSED + FAILED)) total"
+exit $((FAILED > 0 ? 1 : 0))


### PR DESCRIPTION
Adds `--result-socket <path>` CLI option. The runtime sends main-thread results and process lifecycle events as newline-delimited JSON over a Unix domain socket, providing an out-of-band alternative to stdout parsing.

All exit paths wired up (normal, timeout, SIGINT, explicit `exit()`). Stdout result message auto-suppressed when socket is active. 13 automated tests included. 856 golden tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)