### PR TITLE
Troupe Notebook: execution manager, settings panel, and user guide notebooks

### DIFF
--- a/examples/userguide-tpnb/basic-features.tpnb
+++ b/examples/userguide-tpnb/basic-features.tpnb
@@ -1,0 +1,324 @@
+{
+  "troupe_notebook": 1,
+  "options": {
+    "nmifc": true,
+    "labelFormat": "v1",
+    "timeout": 10
+  },
+  "cells": [
+    {
+      "id": "cell-1-09cf40",
+      "type": "markdown",
+      "source": "# Troupe basic features\n\nThis is an interactive guide that requires Troupe is installed on your system, with appropriately set environment variables.\n\n## A minimal Troupe program\n\nWe start with an example of a small Troupe program that returns number 42 as its result."
+    },
+    {
+      "id": "cell-1-2one4k",
+      "type": "code",
+      "source": "42",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "42@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-3-20b0f5",
+      "type": "markdown",
+      "source": "If you want to run this program outside of the Troupe notebook, this program can be compiled, executed, and inspected for the return value using the following sequence of shell commands."
+    },
+    {
+      "id": "cell-4-d4b6c7",
+      "type": "markdown",
+      "source": "```\n$ $TROUPE/bin/troupec program.trp -o out.js\n$ $TROUPE/rt/troupe out.js --localonly \n...\nmain thread finished with value: 42@{}%{}\n```"
+    },
+    {
+      "id": "cell-5-d5324c",
+      "type": "markdown",
+      "source": "The first command here invokes the Troupe compiler and specifies the generated output file to be `out/program.js`.\nThe second command invokes the nodejs runtime on the generated file. Note `--localonly` flag that \nprevents the runtime from initializing the network layer -- we discuss the network layer in Section Network.\nTroupe installation also includes a shell script `local.sh` that combines the above two tasks of compiling \nand running the programs.\n\nObserve the format of the output value `42@{}%{}`. This value is *labeled* and consists of three \nparts: the base value 42, the security label of the value after the @ sign, \nand the security label of the type after the % sign. Here, `{}` that means the lowest security level.\n\n## Overview of the basic language\n\nAt the very core of Troupe is a dynamically typed functional programming language without mutable references. \nFor example, a Fibonacci function in Troupe is written exactly as in SML sans type annotations."
+    },
+    {
+      "id": "cell-6-c9c185",
+      "type": "code",
+      "source": "let fun fib x = \n        if x > 2 then fib (x - 1) + fib (x - 2)\n                 else 1\nin fib 10\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "55@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-7-9b1d38",
+      "type": "markdown",
+      "source": "Running this program results in the output"
+    },
+    {
+      "id": "cell-8-8a424f",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nmain thread finished with value: 55@{}%{}\n```"
+    },
+    {
+      "id": "cell-9-938d83",
+      "type": "markdown",
+      "source": "Note that Troupe is dynamically typed. For example, a program such as `1 + ()` results in a \nruntime type error"
+    },
+    {
+      "id": "cell-2-3ckeld",
+      "type": "code",
+      "source": "1 + ()",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "Runtime error in thread 84144e76-6653-41a9-814d-076ccd7186ee@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": ">> value () is not a number\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-10-7850d1",
+      "type": "markdown",
+      "source": "```\nRuntime error in thread b279c491-4509-48e0-82fa-15f18de96003@{}%{}\n   value ()@{} is not a number    \n```"
+    },
+    {
+      "id": "cell-11-a3590f",
+      "type": "markdown",
+      "source": "## Types and values\n\nTroupe has the following types:\n\n- **Unit**: Unit type with the unit value `()`.\n- **Booleans**: Boolean type with literals `true` and `false`.\n- **Number**: Number type.\n- **String**: String type. String literals are created by placing text between double quotes, e.g., \"hello, world\".\n- **Tuple**: Tuple aggregate, e.g., `(\"hello\", (), true, 42)`.\n- **List**: List aggregate, with empty list denoted as `[]`.\n- **Record**: Record aggregate with named fields, e.g., `{x = 10, y = \"hello\"}`.\n- **Function**: Function type. Function values are created either using `fn x => e` syntax or using the let-fun declarations (cf. Function declarations section).\n- **Process Id**: Process identifier (cf. Concurrency section).\n- **Label**: Security label (cf. Information flow control section).\n- **Authority**: Declassification capability (cf. Declassification section).\n\nNote that strings are also used for referring to node identities.\n\n## Core language features\n\nTroupe uses an SML-like syntax for its core language. This section explains the syntax of every language as it presents them.\n\n### Basic operations\n\nTroupe supports basic arithmetic and comparison operations on numbers. The comparison is also extended to strings. \nAggregates support equality checks that is defined as point-wise equality of their elements. Boolean conjunction is \n`andalso`, and boolean disjunction is `orelse`. List cons operation is `::` and \nstring concatenation is `^`.\n\n\n### If expressions\n\nConditionals have the form `if e0 then e1 else e2`, where `e0` is the guard of the conditional. \nThe branch `e1` is chosen if `e0` evaluates to true; otherwise, the branch `e2` is chosen.\n\n### Case expressions\n\nCase expressions have the form\n```\ncase e of \n   pat_1 => e_1\n | pat_2 => e_2 \n |  ...\n | pat_n => e_n\n```\n\nHere, `pat_1`, ..., `pat_n` are the patterns that are matched against the expression `e`, and the `e_1`, ..., `e_n` are the \nexpressions to evaluate. Patterns range over literals, including `()`, booleans, numbers, and string literals, as well as the \naggregate constructors, and the wildcard pattern _.\n\n### Let expressions\n\nLet expressions are used for binding names to values. The basic value binding uses the `let val` syntax. \nSeveral binding may appear in one block, and references to the earlier bindings in the block are allowed."
+    },
+    {
+      "id": "cell-14-e157e2",
+      "type": "code",
+      "source": "let val x = 20\n    val y = x + 2\nin x + y\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "42@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-15-46fc40",
+      "type": "markdown",
+      "source": "### Function declarations\n\nFunctions are declared using `let fun` syntax. Mutually recursive functions \nare delimited using the `and` keyword."
+    },
+    {
+      "id": "cell-16-3d4062",
+      "type": "code",
+      "source": "let fun even x = if x = 0 then true else odd (x - 1)\n    and odd x = if x = 0 then false else even (x - 1)\nin even 7\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "false@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-17-8b381f",
+      "type": "markdown",
+      "source": "Function application has the form `e0 e1`. Curried function declarations and partial \napplication is supported, e.g.:"
+    },
+    {
+      "id": "cell-18-db7caa",
+      "type": "code",
+      "source": "let fun add2 x y = x + y \n    val inc = add2 1 \nin inc 10\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "11@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-19-9b687c",
+      "type": "markdown",
+      "source": "### Records\n\nRecords are aggregate data structures with named fields. They provide a convenient way to group related values together.\n\n#### Record creation\n\nRecords are created using curly braces with field-value pairs:"
+    },
+    {
+      "id": "cell-20-6d3adb",
+      "type": "code",
+      "source": "let val point = {x = 10, y = 20}\n    val person = {name = \"Alice\", age = 30, active = true}\nin person\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "{name=\"Alice\"@{}%{}, age=30@{}%{}, active=true@{}%{}}@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-21-cf473f",
+      "type": "markdown",
+      "source": "Empty records are also valid:"
+    },
+    {
+      "id": "cell-22-a4ba57",
+      "type": "code",
+      "source": "{}",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "{}@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-23-e17d98",
+      "type": "markdown",
+      "source": "Records can contain any type of value, including functions:"
+    },
+    {
+      "id": "cell-24-558e6d",
+      "type": "code",
+      "source": "let val obj = {a = 10, b = \"Hello\", f = fn x => x + 1}\nin obj.f(obj.a)  (* returns 11 *)\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "11@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-25-87ba81",
+      "type": "markdown",
+      "source": "#### Field name shorthand\n\nWhen creating a record, if a field name matches a variable name in scope, you can use shorthand notation:"
+    },
+    {
+      "id": "cell-26-9b775f",
+      "type": "code",
+      "source": "let val name = \"Bob\"\n    val age = 25\n    val person = {name, age, city = \"New York\"}  (* name and age use shorthand *)\nin person\nend"
+    },
+    {
+      "id": "cell-27-13d77a",
+      "type": "markdown",
+      "source": "#### Field access\n\nRecord fields are accessed using dot notation:"
+    },
+    {
+      "id": "cell-28-b33867",
+      "type": "code",
+      "source": "let val point = {x = 100, y = 200}\nin point.x + point.y  (* returns 300 *)\nend"
+    },
+    {
+      "id": "cell-29-e72e80",
+      "type": "markdown",
+      "source": "#### Record update with `with`\n\nThe `with` syntax creates a new record based on an existing one with modified or additional fields:"
+    },
+    {
+      "id": "cell-30-6b6b88",
+      "type": "code",
+      "source": "let val point0 = {x = 0, y = 0}\n    val point1 = {point0 with x = 10}      (* updates x field *)\n    val point2 = {point0 with z = 5}       (* adds new z field *)\nin (point1, point2)  (* returns ({x = 10, y = 0}, {x = 0, y = 0, z = 5}) *)\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "({x=10@{}%{}, y=0@{}%{}}@{}%{}, {x=0@{}%{}, y=0@{}%{}, z=5@{}%{}}@{}%{})@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-31-399e12",
+      "type": "markdown",
+      "source": "#### Pattern matching with records\n\nRecords can be destructured in let bindings and case expressions. There are two forms of record patterns:\n\n**Exact pattern matching**: When you pattern match on a record without the `..` marker, the pattern matches only records with exactly the specified fields:"
+    },
+    {
+      "id": "cell-32-183721",
+      "type": "code",
+      "source": "(* Exact pattern matching - matches only records with fields a and f *)\nlet val record = {a = 10, b = \"Hello\", f = fn x => x + 1}\n    val {a, f} = record  (* Error: pattern expects exactly fields a and f *)\nin f a\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "Runtime error in thread b097b0c7-b914-41e6-be57-821f6c63facf@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "  3 |     val {a, f} = record  (* Error: pattern expects exactly fields a and f *)\n"
+        },
+        {
+          "type": "stdout",
+          "data": "    |         ^\n"
+        },
+        {
+          "type": "stdout",
+          "data": ">> pattern match failure in let declaration\n"
+        },
+        {
+          "type": "stdout",
+          "data": ">> at /var/folders/8w/fmq_y9hj22j0qjvyrvrzj2nr0000gn/T/troupe-nb-6f9ef4c8.trp:3:9\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-33-3cbe26",
+      "type": "markdown",
+      "source": "**Partial pattern matching with `..`**: When you include the `..` marker at the end of  a record pattern, it matches records that have at least the specified fields, ignoring any additional fields:"
+    },
+    {
+      "id": "cell-34-e63a2a",
+      "type": "code",
+      "source": "(* Partial pattern matching - matches records with at least fields a and f *)\nlet val record = {a = 10, b = \"Hello\", f = fn x => x + 1}\n    val {a, f, ..} = record  (* extracts fields a and f, ignores b *)\nin f a  (* returns 11 *)\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "11@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-35-19a7ac",
+      "type": "markdown",
+      "source": "This distinction is particularly useful in functions where you want to accept records with specific required fields while allowing additional fields:"
+    },
+    {
+      "id": "cell-36-62bc85",
+      "type": "code",
+      "source": "(* Function accepting records with at least field 'a' *)\nlet fun getA (x) = \n  let val {a, ..} = x in a end\n    \nin (getA {a = 10},              (* returns 10 *)\n    getA {a = 20, b = \"hi\"},    (* returns 20 *)\n    getA {a = 30, b = 1, c = 2}) (* returns 30 *)\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "(10@{}%{}, 20@{}%{}, 30@{}%{})@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-37-3fd019",
+      "type": "markdown",
+      "source": "Pattern matching in case expressions also supports both forms:"
+    },
+    {
+      "id": "cell-38-885051",
+      "type": "code",
+      "source": "(* Pattern matching in case expression *)\nlet val point = {x = 10, y = 20, z = 30}\nin case point of\n     {x = 0, y = 0} => \"2D origin\"          (* matches only 2D points *)\n   | {x = 0, y = 0, z = 0} => \"3D origin\"   (* matches only 3D points *)\n   | {x = 0, ..} => \"on yz-plane\"           (* matches any record with x = 0 *)\n   | {x, y, ..} => \"point with x=\" ^ toString x ^ \", y=\" ^ toString y\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "\"point with x=10, y=20\"@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-39-7c7fd8",
+      "type": "markdown",
+      "source": "Note that the `..` marker must be in the last position in the record pattern.\n\n#### Important notes about records\n\n1. **Field order independence**: Records with the same fields and values are equal regardless of field order:\n   ```troupe\n   {a = 1, b = 2} = {b = 2, a = 1}  (* true *)\n   ```\n\n2. **Duplicate fields**: If a record literal contains duplicate field names, the second value is used:\n   ```troupe\n   {x = 100, x = 200}.x  (* returns 200 *)\n   ```\n\n3. **Record pattern must use unique names**.\n"
+    },
+    {
+      "id": "cell-1-ymdft1",
+      "type": "markdown",
+      "source": "## Libraries\n\nTroupe has a minimal support for built-in libraries. Current libraries include a library `lists` for common list manipulations, library `declassifyutil` for declassification of aggregate data structures, and library\n`stdio` with convenient wrappers for standard input and output. To use a library, one needs to import it with an `import` statement at the top of the program."
+    },
+    {
+      "id": "cell-40-95b774",
+      "type": "code",
+      "source": "import List\nprintWithLabels (map ( fn i => i + 1) [1,2,3])",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "[2@{}%{}, 3@{}%{}, 4@{}%{}]@{}%{}\n"
+        },
+        {
+          "type": "result",
+          "data": "()@{}%{}"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/userguide-tpnb/concurrency.tpnb
+++ b/examples/userguide-tpnb/concurrency.tpnb
@@ -1,0 +1,143 @@
+{
+  "troupe_notebook": 1,
+  "options": {
+    "nmifc": true,
+    "labelFormat": "v1",
+    "timeout": 10
+  },
+  "cells": [
+    {
+      "id": "cell-1-57ac14",
+      "type": "markdown",
+      "source": "# Concurrency\n\n## Spawning processes\n\nNew processes are created using `spawn` function that takes as its argument a unit-argument function. \nIt return the process identifier of the new process, and starts the new process that from now on runs concurrently with the \nparent process."
+    },
+    {
+      "id": "cell-2-64311d",
+      "type": "code",
+      "source": "import List\nlet fun printwait x = let val _ = printWithLabels x in sleep 10 end\n    fun foo () = map printwait [1,2,3]\n    fun bar () = map printwait [\"A\", \"B\", \"C\"]\nin  (spawn foo, spawn bar)\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "(8365458e-e6a7-452e-b9ab-407cddf6f655@{}%{}, e5dc85bc-2de4-45be-afa2-b38001746018@{}%{})@{}%{}"
+        },
+        {
+          "type": "stdout",
+          "data": "1@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "\"A\"@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "2@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "\"B\"@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "3@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "\"C\"@{}%{}\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-3-421108",
+      "type": "markdown",
+      "source": "Execution of this program yields the following output:"
+    },
+    {
+      "id": "cell-4-01ec71",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nmain thread finished with value: (ae07ebcc-8a36-401e-b755-ff2393588c87@{}%{}, \ned165a5d-acb0-4c6e-9843-29d9f263c6da@{}%{})@{}%{}\n1@{}%{}\n\"A\"@{}%{}\n2@{}%{}\n\"B\"@{}%{}\n3@{}%{}\n\"C\"@{}%{}\n```"
+    },
+    {
+      "id": "cell-5-b9b151",
+      "type": "markdown",
+      "source": "## Sending and receiving messages\n\nProcess communication in Troupe happens via message passing. Every process has a designated mailbox,\nand other processes may send messages to that mailbox. Only the process that owns the mailbox may pick the messages from it.\n\nTo send a message to another process, we use function `send` that accepts as its argument a tuple of\na process identifier and a value to send. To receive a message from the mailbox, we use function `receive`\nthat accepts as its argument a list of handlers that select a message from the mailbox."
+    },
+    {
+      "id": "cell-6-8247b0",
+      "type": "code",
+      "source": "let fun foo () =\n      receive [hn x => printWithLabels (\"foo received\", x)]\n    val p = spawn foo\nin send (p, \"hello\")\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "()@{}%{}"
+        },
+        {
+          "type": "stdout",
+          "data": "(\"foo received\"@{}%{}, \"hello\"@{}%{})@{}%{}\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-7-25cfa0",
+      "type": "markdown",
+      "source": "**Handlers**\n\nIn the example above, the expression `hn x => ...` is a *handler*. \nHandlers are used for selecting messages from the mailbox. The syntax for handlers is\n\n`hn pat when e1 => e2`\n\nHere, `pat` is the pattern to match, `e1` is the guard expression, and `e2` is the body of the handler. \nThe guard part of the handler (`when e1`) may be omitted. \nWhen several handlers are provided they are used in the order they appear in the list.\nFinally, note that, on each invocation of `receive`, only one message is selected. Subsequent selection\nrequires another call to `receive`.\nFinally, note that handlers are first class (see also the implementation note below).\n\n**Constraints on the guard expressions**\n\nEvaluation of pattern and guard expressions is *sandboxed* -- it may not invoke I/O operations, or \nspawn threads.\n\n**Implementation note**\n\nInternally, handlers are desugared into a function with a case expression that returns a tuple such that the first \nelement of the tuple indicates whether the message should be picked or not, and the second element is the body \nof the handler wrapped in a function, e.g., a value of the form `fn () => e2`.\n\n## Example: receive with a timeout\n\nThe following listing illustrates a program that implements\nreceive with a timeout. In the code below, the primitive `sleep`\nsuspends the execution of the thread for the specified number of milliseconds,\nwhile the primitive `mkuuid` creates a unique string.\nThe use of the unique string avoids creating a confusion when multiple\ntimeouts may be involved."
+    },
+    {
+      "id": "cell-8-70c5cc",
+      "type": "code",
+      "source": "let fun timeout p r t = let val _ = sleep t\n                        in send (p, r)\n                        end\n    val p = self () \n    val r = mkuuid () \n    val _ = spawn ( fn () => timeout p r 1000)    \nin receive [ hn (\"MESSAGE\", x) => print x\n           , hn s when s = r => print \"timeout\" \n           ]\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "\"timeout\"\n"
+        },
+        {
+          "type": "result",
+          "data": "()@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-9-c5edd7",
+      "type": "markdown",
+      "source": "## Example: updateable service\n\nThe listing below presents an example of an updateable service -- \nthis is implemented by having a dedicated handler selecting on \nmessages with the `\"UPDATE\"` string."
+    },
+    {
+      "id": "cell-10-004518",
+      "type": "code",
+      "source": "import timeout\nlet fun v_one n =\n         receive [ hn (\"REQUEST\", senderid) => \n                        let val _ = send (senderid, n) \n                        in v_one (n+1) \n                        end\n                 , hn (\"UPDATE\", newversion) => newversion n\n                 ]\n                 \n    val service = spawn (fn () => v_one 0)\n    val _ = send (service, (\"REQUEST\", self()))\n    val _ = receive [ hn x => print x]\n                    \n    fun v_two n =\n        receive [ hn (\"REQUEST\", senderid) => \n                        let val _ = send (senderid, n) \n                         in v_two (n+1) \n                        end\n                , hn (\"COMPUTE\", senderid, f, x) =>\n                        let val _ = send (senderid, f x)\n                         in v_two (n+1)\n                        end\n                , hn (\"UPDATE\", newversion) => newversion n\n                ]\n\n    val _ = send (service, (\"UPDATE\", v_two))\n    val _ = send (service, (\"COMPUTE\", self(), fn x => x * x, 42))\n    val _ = receive [ hn x => print x]\nin exitAfterTimeout authority 1000 0 \n        \"force terminating the server example after 1s\"; ()\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "0\n"
+        },
+        {
+          "type": "stdout",
+          "data": "1764\n"
+        },
+        {
+          "type": "result",
+          "data": "()@{}%{}"
+        },
+        {
+          "type": "stdout",
+          "data": "force terminating the server example after 1s\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-11-17c709",
+      "type": "markdown",
+      "source": "The evaluation of this program results in the output"
+    },
+    {
+      "id": "cell-12-f17a43",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\n0@{}%{}\n1764@{}%{}\nmain thread finished with value: ()@{}%{}\nforce terminating the server example after 1s\n```"
+    },
+    {
+      "id": "cell-13-f7b813",
+      "type": "markdown",
+      "source": "## Debugging concurrent programs\n\nTo help debugging concurrent programs, one can use a special primitive `_setProcessDebuggingName` that\ntakes a string argument and uses that string when reporting errors in the process. By design, there is no mechanism\nfor reading the process name other than causing an error; this prevents using process names to leak information."
+    }
+  ]
+}

--- a/examples/userguide-tpnb/information-flow.tpnb
+++ b/examples/userguide-tpnb/information-flow.tpnb
@@ -1,0 +1,274 @@
+{
+  "troupe_notebook": 1,
+  "options": {
+    "nmifc": true,
+    "labelFormat": "v1",
+    "timeout": 10
+  },
+  "cells": [
+    {
+      "id": "cell-1-ca8223",
+      "type": "markdown",
+      "source": "# Information flow control\n\nTroupe implements dynamic information flow control. Information flow violations result in termination of a process, unless the process is sandboxed.\n\n**Labeled values**\n\nEvery value in Troupe is *deeply labeled* with confidentiality levels. The security level of a value specifies the confidentiality policy of the value. Troupe uses the syntax `v@{ℓ_val}%{ℓ_type}` to denote that the value `v` has security level `ℓ_val`, and the information about the type of this value is labeled at `ℓ_type`.\n\n**Remark**\n\nCurrent version of Troupe only enforces confidentiality properties.\n\n## Tag-based label model\n\nThe current version of Troupe uses a simple tag-based label model. Tags are abstract identifiers, e.g., `alice`, `bob`, `secret`, that specify confidentiality restrictions on data. A security level is a set of tags, e.g., `{alice, bob}`, or `{alice, bob, charlie}`. The more tags there are in the level the more restrictive is the data. For example, the level `{alice, bob}` is less restrictive than `{alice, bob, charlie}`. The least restrictive level is the empty set level `{}`. When two levels are ordered we write ℓ₁ ⊑ ℓ₂ to say that level ℓ₂ is as restrictive as ℓ₁.\n\n## Monitoring for information flow\n\nA labeled value can be created using Troupe's `raisedTo` primitive. Troupe's runtime propagates labels throughout the computation. This section presents examples of label propagation via explicit flows, implicit flows, and finally via termination and blocking.\n\n**Explicit flows**\n\nThe following example shows how to create labeled values and how explicit dependencies are propagated."
+    },
+    {
+      "id": "cell-2-27ed1e",
+      "type": "code",
+      "source": "let val x = 10 raisedTo `{alice}`\n    val y = 20 raisedTo `{bob}`\nin x + y\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "30@{alice,bob}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-3-d7d1ad",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nmain thread finished with value: 30@{alice,bob}%{}\n```"
+    },
+    {
+      "id": "cell-4-24069e",
+      "type": "markdown",
+      "source": "**Relationship between type and value labels**\n\nObserve how the result of this computation is labeled with the level `{alice, bob}`, but the type label is `{}`. Because information about the value is more precise than the information about the type, it holds that ℓ_type ⊑ ℓ_val.\n\n**Labels as values and label comparison**\n\nLabels in Troupe are first-class:"
+    },
+    {
+      "id": "cell-5-eaeba6",
+      "type": "code",
+      "source": "import List\nmap (fn (x,lev) => x raisedTo lev) [ (1, `{alice}`)\n                                   , (2, `{bob}`)\n                                   , (3, `{charlie}`) ]",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "[1@{alice}%{}, 2@{bob}%{}, 3@{charlie}%{}]@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-6-d352e4",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\n>>> Main thread finished with value: [1@{alice}%{}, 2@{bob}%{}, \n3@{charlie}%{}]@{}%{}\n```"
+    },
+    {
+      "id": "cell-7-ee3689",
+      "type": "markdown",
+      "source": "**Implicit flows**\n\nConditionals propagate the flows as well:"
+    },
+    {
+      "id": "cell-8-cf88d8",
+      "type": "code",
+      "source": "let val x = 10 raisedTo `{alice}` \nin if x > 5 then 1 else 0 \nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "1@{alice}%{alice}"
+        }
+      ]
+    },
+    {
+      "id": "cell-9-ba1f85",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nmain thread finished with value: 1@{alice}%{alice}\n```"
+    },
+    {
+      "id": "cell-10-1a85ff",
+      "type": "markdown",
+      "source": "Observe how the final value carries the dependency of the branch that has been chosen here. Because, of the dynamic nature of type checking, we also carry the information about the chosen branch into the type label.\n\n**Implicit flows and I/O**\n\nThe implicit information flows are further propagated between processes. In the mailbox, each message is additionally tagged with a label that corresponds to the blocking level of the sender at the time when the message was sent. Troupe supports filtering messages based on these tags. In the following example, `rcvp` is a form of receive statement that selects messages where the pc-tag set to the provided label argument."
+    },
+    {
+      "id": "cell-11-089060",
+      "type": "code",
+      "source": "let val x = 10 raisedTo `{secret}`\n    val p = self()\n    val _ = spawn ( fn () => if x > 0 \n                               then send (p, 1) \n                               else send (p, 0) )\nin rcvp (`{secret}`, [ hn x => x ])\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "1@{secret}%{secret}"
+        }
+      ]
+    },
+    {
+      "id": "cell-12-7a744b",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nmain thread finished with value: 1@{secret}%{secret}\n```"
+    },
+    {
+      "id": "cell-13-4e2866",
+      "type": "markdown",
+      "source": "**Termination and blocking flows**\n\nIn addition to tracking implicit flows via control flow, Troupe also tracks possible leaks via program termination or blocking. The sources of blocking are all synchronous operations such as receive statements or reading from standard input. Each thread has two runtime labels: the program counter label `pc`, and the blocking (termination) label `block`. It is always the case that `pc ⊑ block`. To view the labels there is a helper internal function `debugpc ()`."
+    },
+    {
+      "id": "cell-14-912052",
+      "type": "code",
+      "source": "let val x = 1 raisedTo `{secret}`\n    val _ = debugpc() \n    val x = if x > 2 then receive [] else () \n    val _ = debugpc() \nin () \nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "PID:47d40d16-8cae-426d-bf2d-9849089b73fe@{}%{}     PC:{}                BL:{}                HNNORMAL             _sp:13               \n"
+        },
+        {
+          "type": "stdout",
+          "data": "PID:47d40d16-8cae-426d-bf2d-9849089b73fe@{}%{}     PC:{}                BL:{secret}          HNNORMAL             _sp:13               \n"
+        },
+        {
+          "type": "result",
+          "data": "()@{secret}%{secret}"
+        }
+      ]
+    },
+    {
+      "id": "cell-15-806921",
+      "type": "markdown",
+      "source": "Each call to `debugpc` prints out the information about the process identifier, the pc label, and the blocking label."
+    },
+    {
+      "id": "cell-16-194a89",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nPID:2dfe86ae-6bf3-4bfc-8a0c-200230e0296c@{}%{}     PC:{}       BL:{}                \nPID:2dfe86ae-6bf3-4bfc-8a0c-200230e0296c@{}%{}     PC:{}       BL:{secret}\n```"
+    },
+    {
+      "id": "cell-17-dec1de",
+      "type": "markdown",
+      "source": "As one can see from the output above, the pc label after the conditional statement is lowered back to `{}`, but the blocking label remains tainted with the label of the branch. The distinction between the two labels is helpful when declassifying the blocking label.\n\n**Implicit flows and type labels**\n\nType labels of values created in branches are also tainted by the pc-label. Operations that check the type label, e.g., arithmetics or pattern matching, use the information in the type label to appropriately taint the blocking level. the value."
+    },
+    {
+      "id": "cell-18-fb742e",
+      "type": "code",
+      "source": "let val x = 100 raisedTo `{alice}`\n    val y = 200 raisedTo `{bob}`\n    val z = 300 raisedTo `{charlie}`\n    val a = let pini authority \n                val a = if y > 10 then z else \"not an integer\"\n            in a \n            end\n    val _ = printWithLabels a\n    val _ = debugpc()\n    val w = a + x\n    val _ = printWithLabels w\nin debugpc()\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "300@{bob,charlie}%{bob}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "PID:a577cfdd-9dba-49db-bc1a-2b33908bce0b@{}%{}     PC:{}                BL:{}                HNNORMAL             _sp:25               \n"
+        },
+        {
+          "type": "stdout",
+          "data": "400@{alice,bob,charlie}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": "PID:a577cfdd-9dba-49db-bc1a-2b33908bce0b@{}%{}     PC:{}                BL:{bob}             HNNORMAL             _sp:25               \n"
+        },
+        {
+          "type": "result",
+          "data": "()@{bob}%{bob}"
+        }
+      ]
+    },
+    {
+      "id": "cell-19-142ca0",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\n300@{charlie,bob}%{bob}\nPID:2dfdc81f-1027-40e2-810c-11fadb2dd40f@{}%{}     PC:{}          BL:{}\n400@{charlie,bob,alice}%{}\nPID:2dfdc81f-1027-40e2-810c-11fadb2dd40f@{}%{}     PC:{}          BL:{bob}\n```"
+    },
+    {
+      "id": "cell-20-45ac85",
+      "type": "markdown",
+      "source": "**Implementation note**\n\nTroupe implements information flow enforcement via inlining.\n\n## Declassification and progress-sensitivity\n\nTo relax the constraints imposed by the information flow control, Troupe offers a mechanism for *declassification*.\n\n### Authority\n\nIn Troupe, declassifying information requires a capability to declassify, known as the *declassification authority*. The authority carries a security level that is the upper bound on what information it can declassify.\n\nGiven a value at level ℓ_from, an authority of level ℓ_auth permits a declassification to level ℓ_to if ℓ_from ⊑ ℓ_to ∪ ℓ_auth.\n\nAuthorities in Troupe are capabilities, which means that they cannot be created out of thin air. At the start of a Troupe program, the top-level authority is bound to variable `authority`. This authority can be used freely by the program. Note, however, that the authority is not available to code that is imported from the libraries or to code that is received over the network.\n\n### Attenuation\n\nAuthority can be attenuated using the `attenuate` primitive."
+    },
+    {
+      "id": "cell-21-9f648e",
+      "type": "code",
+      "source": "attenuate (authority, `{alice}`)",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "!{alice}@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-22-ac8213",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\n>>> Main thread finished with value: !{alice}@{}%{}\n```"
+    },
+    {
+      "id": "cell-23-77717c",
+      "type": "markdown",
+      "source": "### Basic declassification\n\nTroupe provides an explicit declassification command `declassify` that takes three arguments: the expression to declassify, the authority, and the target label. For example, a basic declassification looks like this."
+    },
+    {
+      "id": "cell-24-7497e7",
+      "type": "code",
+      "source": "let val x = 10 raisedTo `<alice; #root-integrity>`\n in declassify (x , authority, `<;#root-integrity>` )\nend",
+      "outputs": [
+        {
+          "type": "result",
+          "data": "10@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-25-31fe3c",
+      "type": "markdown",
+      "source": "When authority for declassification is not sufficient, Troupe returns an error message."
+    },
+    {
+      "id": "cell-26-654396",
+      "type": "code",
+      "source": "let val authAlice = attenuate (authority, `{alice}`)\n    val x = 1 raisedTo `{bob}`\nin declassify (x, authAlice, `{}`)\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "Runtime error in thread c76090fb-cefc-414f-b826-6c4315cb4dda@{}%{}\n"
+        },
+        {
+          "type": "stdout",
+          "data": ">> Integrity level mismatch for declassification\n"
+        },
+        {
+          "type": "stdout",
+          "data": " | integrity level of the data: bob\n"
+        },
+        {
+          "type": "stdout",
+          "data": " | integrity level of the target: #root-integrity\n"
+        }
+      ]
+    },
+    {
+      "id": "cell-27-01d381",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nRuntime error in thread b469cbef-16d3-4fe8-ac1e-bd21c7e8950d@{}%{}\n>> Not enough authority for declassification\n | level of the data: {bob}\n | level of the authority: {alice}\n | target level of the declassification: {}\n```"
+    },
+    {
+      "id": "cell-28-2d35d0",
+      "type": "markdown",
+      "source": "### Declassification of the blocking level\n\nThe treatment of the blocking and termination labels is often restrictive in practice. To relax this, Troupe provides declassification of the blocking label. This is done using a variant of the `let` declaration that is called `let pini`. This statement requires the authority argument to declassify the blocking label after the sequence of the declarations (i.e., just before the `in` block). These declarations are accessible in the body of the let statement at permissive levels."
+    },
+    {
+      "id": "cell-29-91cae5",
+      "type": "code",
+      "source": "let val x = 10 raisedTo `{alice}`\n    val y = 0\n    val z = \n        let pini authority\n          val _ = if x > 1000 then receive [] else ()\n          val z = y + 1\n          val _ = debugpc () \n        in z\n        end\n    val _ = debugpc()\nin z\nend",
+      "outputs": [
+        {
+          "type": "stdout",
+          "data": "PID:142bcd79-62ef-4354-af9e-98d9d981e8c7@{}%{}     PC:{}                BL:{alice}           HNNORMAL             _sp:16               \n"
+        },
+        {
+          "type": "stdout",
+          "data": "PID:142bcd79-62ef-4354-af9e-98d9d981e8c7@{}%{}     PC:{}                BL:{}                HNNORMAL             _sp:16               \n"
+        },
+        {
+          "type": "result",
+          "data": "1@{}%{}"
+        }
+      ]
+    },
+    {
+      "id": "cell-30-70d2c1",
+      "type": "markdown",
+      "source": "**Expected output:**\n```\nPID:54bd148b-912e-4ae9-9787-aaf1166e9bc9@{}%{}     PC:{}       BL:{alice}           \nPID:54bd148b-912e-4ae9-9787-aaf1166e9bc9@{}%{}     PC:{}       BL:{}            \n>>> Main thread finished with value: 1@{}%{}\n```"
+    },
+    {
+      "id": "cell-31-f7edda",
+      "type": "markdown",
+      "source": "Observe that in the above program, the level of the final value `z` is not tainted by the blocking label of the high conditional.\n\n**Implementation note**\n\nThe expression `let pini e0` declarations `in e1 end` is desugared by the compiler frontend into the form:\n\n```\nlet val tmp = pinipush e0 \n    declarations\n    val _ = pinipop tmp\nin e1      \nend\n```\n\nHere, `tmp` is a fresh variable that is not part of the user program. Primitives `pinipush` and `pinipop` dynamically scope the part of the execution for which the blocking label is declassified."
+    },
+    {
+      "id": "cell-33-68adf4",
+      "type": "markdown",
+      "source": "## Information flow control with I/O primitives\n\nThis section may be omitted upon first read as it has a number of information flow subtleties that can be omitted when first starting to use the system.\n\n### Generalized receive and mailbox clearances\n\nI/O operations such as send and receive introduce additional concerns w.r.t. information flow control. In particular, because mailbox acts as a mutable state, an extra care needs to be taken to control information flows through the mailbox structure.\n\nEvery message in a mailbox carries an extra label -- the blocking level of the sender. We refer to this extra label as the *presence label*. Receiving a value furthermore propagates the taint of the blocking level from the sender to the receiver via the presence label. In order to constrain a receive operation from an accidental raise of the blocking level, Troupe provides a general receive primitive in the form `rcv(lev1,lev2,hns)`. Here, `lev1` and `lev2` indicate the to and from-levels of the presence labels on the messages, and `hns` is the list of handlers as before. The `receive` operation we introduced earlier is equivalent to `rcvp` at the level of the current pc label.\n\nWhile such a form of general receive over an interval of levels is useful, it is also too powerful and needs to be further constrained. Consider the following snippet:\n\n```\nlet val _ = if secret then rcv (`{}`, `{alice}`, [hn x => x])\n                      else ()\nin rcv (`{}`, `{}`, [hn x => x])\nend\n```\n\nBecause the receive in the high branch is on an interval, the value of `x` may depend on the secret value. In general, one can encode an entire secret in the structure of the mailbox. To prevent such programs, Troupe provides a special notion of *mailbox clearance* that constrains receives on an interval. The mailbox clearance is a proxy for an authority. It can be raised using a dedicated command `raisembox (lev)` that returns a lowering capability and lowered with command `lowermbox(c, authority)`. There are a few constraints related to the mailbox clearance.\n\n1. In order to receive on an interval (ℓ₁, ℓ₂) under `pc` with mailbox clearance ℓ_clear it must hold that ℓ₂ ∪ pc ⊑ ℓ₁ ∪ ℓ_clear. This constraint ensures that the mailbox clearance is sufficient for the interval receives. When mailbox clearance is ⊥ -- as it is in the beginning of the program -- only point intervals of the form (ℓ, ℓ) where pc ⊑ ℓ are allowed.\n\n2. The `pc`-label of the program point where the mailbox clearance is raised affects the lower bound of the intervals. In particular, if the clearance is raised when the `pc` counter is pc_raise, the mailbox structure cannot be influenced by receives that are not as restrictive as pc_raise; in other words: pc_raise ⊑ pc ∩ ℓ₁, where ℓ₁ is the lower bound of the interval receive.\n\n3. If the process mailbox clearance is raised in a branch, it must be lowered back before reaching the join point of the branch."
+    }
+  ]
+}

--- a/notebook/CLAUDE.md
+++ b/notebook/CLAUDE.md
@@ -9,3 +9,7 @@ Color coding (border colors, background tints) can be used as a supplementary vi
 - **Execution state**: Running/idle state should be indicated by button changes (Run vs Stop) and text, not just border color.
 
 This ensures information is accessible regardless of color perception and is unambiguous at a glance.
+
+## Avoid unnecessary capitalization in UI elements
+
+Do not use uppercase or `text-transform: uppercase` for UI labels, section headings in panels, or button text unless there is a strong convention for it (e.g., single-word cell type badges like "CODE" or "MD"). Prefer sentence case for labels and headings.

--- a/notebook/public/css/notebook.css
+++ b/notebook/public/css/notebook.css
@@ -363,6 +363,30 @@ header h1 {
     display: block;
     color: #2c3e50;
     font-weight: 600;
+    border-left: 3px solid #3498db;
+    padding-left: 8px;
+    margin-top: 4px;
+    background: rgba(52, 152, 219, 0.04);
+}
+
+/* Result style prefix variants (controlled by data-result-style on #notebook) */
+.cell-output .result::before {
+    color: #7f8c8d;
+    font-weight: 400;
+}
+[data-result-style="out"] .cell-output .result::before {
+    content: 'Out: ';
+}
+[data-result-style="triangle"] .cell-output .result::before {
+    content: '\25B8 ';
+}
+[data-result-style="val"] .cell-output .result::before {
+    content: 'val ';
+    font-style: italic;
+}
+[data-result-style="cli"] .cell-output .result::before {
+    content: '>>> Main thread finished with value: ';
+    font-weight: 400;
 }
 
 .cell-output .exit-code {
@@ -641,6 +665,52 @@ header h1 {
     background: #ecf0f1;
     border-color: #888;
     color: #333;
+}
+
+/* Settings panel */
+.settings-btn {
+    background: none;
+    border: 1px solid rgba(255,255,255,0.3);
+    color: white;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    line-height: 1;
+}
+.settings-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+.settings-panel {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 8px 16px 10px;
+    background: #f8f9fa;
+    border-bottom: 1px solid #ddd;
+    display: none;
+    font-size: 13px;
+    color: #555;
+}
+.settings-panel.open {
+    display: block;
+}
+.settings-panel h3 {
+    font-size: 12px;
+    color: #7f8c8d;
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+.settings-panel .option-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.settings-panel .option-item select {
+    font-size: 12px;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background: white;
 }
 
 /* File picker overlay */

--- a/notebook/public/css/notebook.css
+++ b/notebook/public/css/notebook.css
@@ -360,19 +360,13 @@ header h1 {
 }
 
 .cell-output .result {
+    display: block;
     color: #2c3e50;
     font-weight: 600;
-    border-top: 1px solid #eee;
-    padding-top: 4px;
-    margin-top: 4px;
-}
-
-.cell-output .result::before {
-    content: "=> ";
-    color: #7f8c8d;
 }
 
 .cell-output .exit-code {
+    display: block;
     color: #e74c3c;
     font-weight: 600;
     font-style: italic;
@@ -400,6 +394,14 @@ header h1 {
 .cell.markdown-cell .cell-rendered pre code {
     display: block;
     padding: 8px;
+}
+.cell.markdown-cell .cell-rendered ul,
+.cell.markdown-cell .cell-rendered ol {
+    margin: 6px 0;
+    padding-left: 24px;
+}
+.cell.markdown-cell .cell-rendered li {
+    margin: 2px 0;
 }
 
 .add-cell-bar {

--- a/notebook/public/index.html
+++ b/notebook/public/index.html
@@ -24,6 +24,8 @@
             <button id="btn-export" title="Export notebook as .tpnb file">Export</button>
             <button id="btn-import" title="Import .tpnb file from disk">Import</button>
             <input type="file" id="import-file-input" accept=".tpnb" style="display:none">
+            <span class="toolbar-separator"></span>
+            <button id="btn-settings" class="settings-btn" title="Display settings">&#9881;</button>
         </div>
     </header>
     <div class="options-bar">
@@ -50,6 +52,19 @@
             Auto-save
         </label>
         <span id="save-status" class="save-status"></span>
+    </div>
+    <div id="settings-panel" class="settings-panel">
+        <h3>Display settings</h3>
+        <label class="option-item" title="How the main thread result value is displayed">
+            Result style:
+            <select id="opt-result-style">
+                <option value="plain" selected>Plain (accent bar)</option>
+                <option value="out">Out:</option>
+                <option value="triangle">&#9656; Triangle</option>
+                <option value="val">val (SML-style)</option>
+                <option value="cli">Main thread finished with value</option>
+            </select>
+        </label>
     </div>
     <main id="notebook">
         <!-- Cells are rendered here -->

--- a/notebook/public/js/app.js
+++ b/notebook/public/js/app.js
@@ -766,7 +766,7 @@ function renderCodeCellBody(cell, el) {
     copyOutBtn.textContent = 'Copy';
     copyOutBtn.title = 'Copy output to clipboard';
     copyOutBtn.onclick = () => {
-        const text = cell.outputEl ? cell.outputEl.textContent : '';
+        const text = cell.outputEl ? cell.outputEl.innerText : '';
         if (!text) return;
         navigator.clipboard.writeText(text).then(() => {
             copyOutBtn.textContent = 'Copied!';

--- a/notebook/public/js/app.js
+++ b/notebook/public/js/app.js
@@ -82,6 +82,7 @@ function getRuntimeOptions() {
         nmifc: document.getElementById('opt-nmifc').checked,
         labelFormat: document.getElementById('opt-label-format').value,
         timeout: Math.max(1, parseInt(document.getElementById('opt-timeout').value, 10) || DEFAULT_TIMEOUT_SECONDS),
+        resultStyle: document.getElementById('opt-result-style').value,
     };
 }
 
@@ -97,6 +98,13 @@ function setRuntimeOptions(options) {
         document.getElementById('opt-timeout').value = options.timeout;
     } else {
         document.getElementById('opt-timeout').value = DEFAULT_TIMEOUT_SECONDS;
+    }
+    if (options.resultStyle) {
+        document.getElementById('opt-result-style').value = options.resultStyle;
+        applyResultStyle(options.resultStyle);
+    } else {
+        document.getElementById('opt-result-style').value = 'plain';
+        applyResultStyle('plain');
     }
 }
 
@@ -1152,6 +1160,22 @@ document.getElementById('opt-timeout').addEventListener('change', markDirty);
 document.getElementById('opt-autosave').addEventListener('change', (e) => {
     setAutoSave(e.target.checked);
 });
+
+// Settings panel toggle
+document.getElementById('btn-settings').addEventListener('click', () => {
+    document.getElementById('settings-panel').classList.toggle('open');
+});
+
+// Result style dropdown
+const resultStyleSelect = document.getElementById('opt-result-style');
+function applyResultStyle(style) {
+    document.getElementById('notebook').setAttribute('data-result-style', style || 'plain');
+}
+resultStyleSelect.addEventListener('change', () => {
+    applyResultStyle(resultStyleSelect.value);
+    markDirty();
+});
+applyResultStyle('plain');
 
 // Drag-and-drop: global listeners on the notebook container
 const notebookContainer = document.getElementById('notebook');

--- a/notebook/src/executionManager.mts
+++ b/notebook/src/executionManager.mts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { constants } from 'node:os';
+import * as net from 'node:net';
 
 const signalNumbers: Record<string, number> = constants.signals as Record<string, number>;
 function signalNumber(sig: string): number | undefined {
@@ -114,95 +115,134 @@ export class ExecutionManager {
         });
     }
 
-    private run(jsFile: string, cellId: string, onOutput: OutputCallback, options?: RuntimeOptions): Promise<void> {
-        return new Promise((resolve) => {
-            const runtime = join(this.troupeRoot, 'rt', 'built', 'troupe.mjs');
-            const runtimeArgs = [
-                '--stack-trace-limit=1000',
-                runtime,
-                '-f=' + jsFile,
-                '--localonly',
-                '--suppress-local-info-message',
-                '--no-color',
-            ];
+    private async run(jsFile: string, cellId: string, onOutput: OutputCallback, options?: RuntimeOptions): Promise<void> {
+        const id = cellId.slice(0, 8);
+        const socketPath = join(tmpdir(), `troupe-nb-result-${id}.sock`);
 
-            const ALLOWED_LABEL_FORMATS = ['v1', 'v2'];
-            if (options) {
-                if (options.nmifc === false) {
-                    runtimeArgs.push('--no-nmifc');
-                }
-                if (options.labelFormat && options.labelFormat !== 'v1'
-                    && ALLOWED_LABEL_FORMATS.includes(options.labelFormat)) {
-                    runtimeArgs.push(`--label-format=${options.labelFormat}`);
-                }
-            }
-            const rawTimeout = (options?.timeout && options.timeout > 0) ? options.timeout : DEFAULT_TIMEOUT_SECONDS;
-            const timeout = Math.min(rawTimeout, MAX_TIMEOUT_SECONDS);
-            runtimeArgs.push(`--timeout=${timeout}`);
+        // Clean up any stale socket file from a previous run
+        await unlink(socketPath).catch(() => {});
 
-            const proc = spawn('node', runtimeArgs, {
-                env: { ...process.env, TROUPE: this.troupeRoot },
-            });
+        // Create the Unix socket server before spawning the runtime
+        const socketServer = net.createServer();
+        await new Promise<void>((resolve, reject) => {
+            socketServer.listen(socketPath, () => resolve());
+            socketServer.on('error', reject);
+        });
 
-            this.running.set(cellId, proc);
-
-            // Safety-net hard kill: if runtime doesn't exit within timeout + 5s grace, force kill
-            {
-                const graceMs = (timeout + 5) * 1000;
-                const timer = setTimeout(() => {
-                    this.timeoutTimers.delete(cellId);
-                    if (proc.exitCode === null) {
-                        proc.kill('SIGKILL');
-                    }
-                }, graceMs);
-                this.timeoutTimers.set(cellId, timer);
-            }
-
-            const mainThreadRe = /^>>> Main thread finished with value: (.+)$/;
-
-            proc.stdout?.on('data', (chunk: Buffer) => {
-                try {
-                    const text = chunk.toString();
-                    for (const line of text.split('\n')) {
-                        if (!line) continue;
-                        const match = mainThreadRe.exec(line);
-                        if (match) {
-                            onOutput('result', match[1]);
-                        } else {
-                            onOutput('stdout', line + '\n');
+        // Handle incoming connection from the runtime
+        let socketBuffer = '';
+        socketServer.on('connection', (conn) => {
+            conn.on('data', (chunk: Buffer) => {
+                socketBuffer += chunk.toString();
+                // Process complete newline-delimited JSON messages
+                let newlineIdx: number;
+                while ((newlineIdx = socketBuffer.indexOf('\n')) !== -1) {
+                    const line = socketBuffer.slice(0, newlineIdx);
+                    socketBuffer = socketBuffer.slice(newlineIdx + 1);
+                    if (!line) continue;
+                    try {
+                        const msg = JSON.parse(line);
+                        if (msg.type === 'main-thread-result' && msg.value != null) {
+                            onOutput('result', msg.value);
+                        } else if (msg.type === 'error' && msg.message) {
+                            onOutput('stderr', msg.message + '\n');
                         }
+                        // process-exit messages are informational; exit code
+                        // comes from the process close event
+                    } catch {
+                        // Ignore malformed JSON
                     }
-                } catch (err) {
-                    console.error('Error in stdout handler:', err);
                 }
-            });
-
-            proc.stderr?.on('data', (chunk: Buffer) => {
-                try {
-                    onOutput('stderr', chunk.toString());
-                } catch (err) {
-                    console.error('Error in stderr handler:', err);
-                }
-            });
-
-            proc.on('close', (code, signal) => {
-                this.clearTimer(cellId);
-                this.running.delete(cellId);
-                // Signal kills: SIGINT→130, SIGKILL→137, etc.
-                const exitCode = code !== null ? code
-                    : signal ? 128 + (signalNumber(signal) || 0)
-                    : 0;
-                onOutput('done', String(exitCode));
-                resolve();
-            });
-
-            proc.on('error', (err) => {
-                this.clearTimer(cellId);
-                this.running.delete(cellId);
-                onOutput('stderr', `Failed to start runtime: ${err.message}\n`);
-                onOutput('done', '1');
-                resolve();
             });
         });
+
+        try {
+            await new Promise<void>((resolve) => {
+                const runtime = join(this.troupeRoot, 'rt', 'built', 'troupe.mjs');
+                const runtimeArgs = [
+                    '--stack-trace-limit=1000',
+                    runtime,
+                    '-f=' + jsFile,
+                    '--localonly',
+                    '--suppress-local-info-message',
+                    '--no-color',
+                    `--result-socket=${socketPath}`,
+                ];
+
+                const ALLOWED_LABEL_FORMATS = ['v1', 'v2'];
+                if (options) {
+                    if (options.nmifc === false) {
+                        runtimeArgs.push('--no-nmifc');
+                    }
+                    if (options.labelFormat && options.labelFormat !== 'v1'
+                        && ALLOWED_LABEL_FORMATS.includes(options.labelFormat)) {
+                        runtimeArgs.push(`--label-format=${options.labelFormat}`);
+                    }
+                }
+                const rawTimeout = (options?.timeout && options.timeout > 0) ? options.timeout : DEFAULT_TIMEOUT_SECONDS;
+                const timeout = Math.min(rawTimeout, MAX_TIMEOUT_SECONDS);
+                runtimeArgs.push(`--timeout=${timeout}`);
+
+                const proc = spawn('node', runtimeArgs, {
+                    env: { ...process.env, TROUPE: this.troupeRoot },
+                });
+
+                this.running.set(cellId, proc);
+
+                // Safety-net hard kill: if runtime doesn't exit within timeout + 5s grace, force kill
+                {
+                    const graceMs = (timeout + 5) * 1000;
+                    const timer = setTimeout(() => {
+                        this.timeoutTimers.delete(cellId);
+                        if (proc.exitCode === null) {
+                            proc.kill('SIGKILL');
+                        }
+                    }, graceMs);
+                    this.timeoutTimers.set(cellId, timer);
+                }
+
+                proc.stdout?.on('data', (chunk: Buffer) => {
+                    try {
+                        const text = chunk.toString();
+                        for (const line of text.split('\n')) {
+                            if (!line) continue;
+                            onOutput('stdout', line + '\n');
+                        }
+                    } catch (err) {
+                        console.error('Error in stdout handler:', err);
+                    }
+                });
+
+                proc.stderr?.on('data', (chunk: Buffer) => {
+                    try {
+                        onOutput('stderr', chunk.toString());
+                    } catch (err) {
+                        console.error('Error in stderr handler:', err);
+                    }
+                });
+
+                proc.on('close', (code, signal) => {
+                    this.clearTimer(cellId);
+                    this.running.delete(cellId);
+                    // Signal kills: SIGINT→130, SIGKILL→137, etc.
+                    const exitCode = code !== null ? code
+                        : signal ? 128 + (signalNumber(signal) || 0)
+                        : 0;
+                    onOutput('done', String(exitCode));
+                    resolve();
+                });
+
+                proc.on('error', (err) => {
+                    this.clearTimer(cellId);
+                    this.running.delete(cellId);
+                    onOutput('stderr', `Failed to start runtime: ${err.message}\n`);
+                    onOutput('done', '1');
+                    resolve();
+                });
+            });
+        } finally {
+            socketServer.close();
+            await unlink(socketPath).catch(() => {});
+        }
     }
 }

--- a/notebook/tools/import-userguide.sh
+++ b/notebook/tools/import-userguide.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copies user guide .tpnb files from examples/userguide-tpnb/ into the
+# notebook storage directory so they are available in the notebook UI.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_DIR="$REPO_ROOT/examples/userguide-tpnb"
+TARGET_DIR="${1:-.notebook-storage}"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "Error: source directory not found: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+count=0
+for f in "$SOURCE_DIR"/*.tpnb; do
+  [ -f "$f" ] || continue
+  cp "$f" "$TARGET_DIR/"
+  echo "Copied $(basename "$f")"
+  count=$((count + 1))
+done
+
+if [ "$count" -eq 0 ]; then
+  echo "No .tpnb files found in $SOURCE_DIR"
+else
+  echo "Imported $count notebook(s) into $TARGET_DIR/"
+fi

--- a/notebook/tools/md2tpnb.mjs
+++ b/notebook/tools/md2tpnb.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+// md2tpnb.mjs — Convert MyST markdown (Jupyter Book) to Troupe notebook (.tpnb)
+//
+// Usage: node md2tpnb.mjs <input.md> [output.tpnb]
+//
+// If output is omitted, derives from input filename.
+// If output is "-", writes to stdout.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, extname, dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+function usage() {
+  console.error('Usage: node md2tpnb.mjs <input.md> [output.tpnb]');
+  process.exit(1);
+}
+
+function genId(index) {
+  const rand = randomBytes(3).toString('hex');
+  return `cell-${index}-${rand}`;
+}
+
+// Detect if a ```text block is shell commands (has $ prompts) vs expected output
+function isShellBlock(lines) {
+  return lines.some(l => /^\s*\$\s/.test(l));
+}
+
+// Strip leading filename comment like (* basic_fib.trp *)
+function stripFilenameComment(source) {
+  const lines = source.split('\n');
+  if (lines.length > 0 && /^\s*\(\*\s*\S+\.(trp|picox|pico|femto|atto)\s*\*\)\s*$/.test(lines[0])) {
+    const rest = lines.slice(1).join('\n');
+    // Also strip leading blank line after the comment
+    return rest.replace(/^\n/, '');
+  }
+  return source;
+}
+
+function convert(mdContent) {
+  const lines = mdContent.split('\n');
+  const cells = [];
+  let cellIndex = 1;
+
+  let inCodeBlock = false;
+  let codeBlockLang = '';
+  let codeBlockLines = [];
+  let proseLines = [];
+  let hasRecentCodeCell = false; // true after a code cell; stays true through prose, cleared on output block
+
+  function flushProse() {
+    const text = proseLines.join('\n').trim();
+    proseLines = [];
+    if (text) {
+      cells.push({
+        id: genId(cellIndex++),
+        type: 'markdown',
+        source: text,
+      });
+      // Don't reset hasRecentCodeCell — prose between code and output is normal
+    }
+  }
+
+  function flushCodeBlock() {
+    const content = codeBlockLines.join('\n');
+    const lang = codeBlockLang.toLowerCase();
+    codeBlockLines = [];
+    codeBlockLang = '';
+
+    if (lang === 'troupe' || lang === 'sml') {
+      // Executable Troupe code cell
+      const source = stripFilenameComment(content).trim();
+      if (source) {
+        cells.push({
+          id: genId(cellIndex++),
+          type: 'code',
+          source,
+        });
+        hasRecentCodeCell = true;
+      }
+    } else if (lang === 'text') {
+      if (isShellBlock(content.split('\n'))) {
+        // Shell commands — keep as markdown fenced code
+        cells.push({
+          id: genId(cellIndex++),
+          type: 'markdown',
+          source: '```\n' + content + '\n```',
+        });
+        hasRecentCodeCell = false;
+      } else if (hasRecentCodeCell) {
+        // Expected output after a code cell
+        cells.push({
+          id: genId(cellIndex++),
+          type: 'markdown',
+          source: '**Expected output:**\n```\n' + content.trim() + '\n```',
+        });
+        hasRecentCodeCell = false;
+      } else {
+        // Generic text block
+        cells.push({
+          id: genId(cellIndex++),
+          type: 'markdown',
+          source: '```\n' + content + '\n```',
+        });
+        hasRecentCodeCell = false;
+      }
+    } else {
+      // Other language tags — keep as markdown fenced code
+      const fence = lang ? '```' + lang : '```';
+      cells.push({
+        id: genId(cellIndex++),
+        type: 'markdown',
+        source: fence + '\n' + content + '\n```',
+      });
+      lastCellWasCode = false;
+    }
+  }
+
+  for (const line of lines) {
+    if (!inCodeBlock) {
+      const fenceMatch = line.match(/^```(\w*)$/);
+      if (fenceMatch) {
+        flushProse();
+        inCodeBlock = true;
+        codeBlockLang = fenceMatch[1] || '';
+        codeBlockLines = [];
+      } else {
+        proseLines.push(line);
+      }
+    } else {
+      if (line === '```') {
+        inCodeBlock = false;
+        flushCodeBlock();
+      } else {
+        codeBlockLines.push(line);
+      }
+    }
+  }
+
+  // Flush any remaining prose
+  flushProse();
+
+  return {
+    troupe_notebook: 1,
+    options: {
+      nmifc: true,
+      labelFormat: 'v1',
+      timeout: 10,
+    },
+    cells,
+  };
+}
+
+// --- Main ---
+
+const args = process.argv.slice(2);
+if (args.length < 1) usage();
+
+const inputPath = args[0];
+const mdContent = readFileSync(inputPath, 'utf-8');
+const notebook = convert(mdContent);
+const json = JSON.stringify(notebook, null, 2) + '\n';
+
+if (args.length >= 2 && args[1] === '-') {
+  process.stdout.write(json);
+} else {
+  const outputPath = args[1] ||
+    join(dirname(inputPath), basename(inputPath, extname(inputPath)) + '.tpnb');
+  writeFileSync(outputPath, json);
+  console.error(`Wrote ${notebook.cells.length} cells to ${outputPath}`);
+}


### PR DESCRIPTION
## Summary

- **Execution manager refactor**: improved execution management for notebook cells (Unix socket IPC integration)
- **Settings panel**: configurable result display styles (plain, Out:, triangle, val/SML-style, CLI-style prefix) via gear-icon settings panel
- **User guide notebooks**: converter tool (`md2tpnb.mjs`) and import script to generate `.tpnb` notebooks from user guide markdown; includes basic-features, concurrency, and information-flow example notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)